### PR TITLE
Info groups hackathon

### DIFF
--- a/markdown/events/2021/hackathon-october-2021.md
+++ b/markdown/events/2021/hackathon-october-2021.md
@@ -101,9 +101,9 @@ We will be a lot of people working in parallel during this hackathon, so to stay
 1. :speech_balloon: Most of the event will happen on [Gather town](gather.town). You can chat there with your group to get an overview of what is going on.
 2. <i class="fab fa-slack"></i> Join the `#hackathon-oct2021-public` Slack channel to stay up to date with the hackathon events.
 3. <i class="fab fa-github"></i> Find a task to work on using the [GitHub Project Board](https://github.com/orgs/nf-core/projects/20).
-    * If you have something you want to do that's not there, please make an issue (e.g. in the nf-core/modules repository if you are adding a new module) and add it to the board
+    - If you have something you want to do that's not there, please make an issue (e.g. in the nf-core/modules repository if you are adding a new module) and add it to the board
 4. :raising_hand: Assign yourself to the issue that you're currently working on (preferably one issue at a time)
-    * This is so that multiple people don't accidentally work on the same task
+    - This is so that multiple people don't accidentally work on the same task
 5. :fast_forward: When you're done, make a pull-request with your changes. Link it to the issue so that the issue closes when merged.
 6. :page_facing_up: Describe your work on the HackMD document [<i class="fas fa-file-alt"></i> HackMD](https://hackmd.io/@nf-core/rkiXus4Bt) for the project and tell the group! :tada:
 7. :recycle: Repeat!


### PR DESCRIPTION
Hi,

here a first draft for adding more info for the hackathon event.

Mostly for @drpatelh , @d4straub, @maxulysse, @jfy133, @FriederikeHanssen to double check that the info about their leading groups is ok. I've put the groups into more thematic groups to include a couple or 3 pipelines that might be sharing modules together in each of the groups. 

Also the link to the HackMD slides needs to be updated once we have the real link.

The Schedule is still missing as I realized it was an html tab, but will find some time to update it soon as well.
