### PR TITLE
fix event button, improve theme handling

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -27,7 +27,8 @@ if (isset($subfooter) and $subfooter) {
             </a>
             <span class="ms-1">and</span>
             <a href="/about#aws">
-              <img src="/assets/img/contributors-colour/aws.svg" alt="Amazon Web Services" class="darkmode-image" style="max-width: 50px">
+              <img src="/assets/img/contributors-white/aws.svg" alt="Amazon Web Services" class="hide-light" style="max-width: 50px">
+              <img src="/assets/img/contributors-colour/aws.svg" alt="Amazon Web Services" class="hide-dark" style="max-width: 50px">
             </a>
           </div>
         </small>

--- a/includes/header.php
+++ b/includes/header.php
@@ -45,6 +45,7 @@ if (isset($subtitle) && strlen($subtitle) > 0) {
   <title><?php echo $page_title; ?></title>
   <meta name="description" content="<?php echo $page_meta; ?>">
   <meta name="author" content="Phil Ewels">
+  <meta name="color-scheme" content="light dark">
   <link rel="shortcut icon" href="/assets/img/logo/nf-core-logo-square.png" type="image/png" />
   <link rel="alternate" type="application/rss+xml" title="nf-core: Events" href="/events/rss" />
   <!-- FontAwesome -->

--- a/public_html/assets/js/nf-core.js
+++ b/public_html/assets/js/nf-core.js
@@ -4,269 +4,360 @@
 //
 
 $(function () {
-    // Enable tooltips
-    $('.mainpage,.footer').tooltip({ //can't use body here, because scrollspy has already an event on it and bootstrap only allows one per selector.
-        selector: '[data-bs-toggle="tooltip"]',
-        html: true
+  // Enable tooltips
+  $(".mainpage,.footer").tooltip({
+    //can't use body here, because scrollspy has already an event on it and bootstrap only allows one per selector.
+    selector: '[data-bs-toggle="tooltip"]',
+    html: true,
+  });
+
+  // Enable code highlighting
+  hljs.highlightAll();
+  // Don't try to guess markdown language to highlight (gets it wrong most of the time)
+  hljs.configure({ languages: [] });
+
+  // Set theme cookie
+  if (
+      window.matchMedia &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches
+  ) {
+      document.cookie =
+          "nfcoretheme=dark; expires=Thu, 2 Dec 2032 12:00:00 UTC; path=/";
+  } else if (
+      window.matchMedia &&
+      window.matchMedia("(prefers-color-scheme: light)").matches
+  ) {
+      document.cookie =
+          "nfcoretheme=light; expires=Thu, 2 Dec 2032 12:00:00 UTC; path=/";
+  }
+  // update cookie when OS theme changes
+  window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
+        var new_theme = e.matches ? "dark" : "light";
+        update_theme(new_theme);
     });
 
-    // Enable code highlighting
-    hljs.highlightAll();
-    // Don't try to guess markdown language to highlight (gets it wrong most of the time)
-    hljs.configure({ languages: [] });
+  $(".theme-switcher label").on('click',function () {
+      var theme = $(this).attr("for").split("-")[1];
 
-    // Function to switch CSS theme file
-    $('.theme-switcher label').click(function () {
-        var theme = $(this).attr("for").split("-")[1];
+      //uncheck all radio buttons and select only current one
+      $(".theme-switcher input:checked").prop("checked", false);
+      $(".theme-switcher #theme-" + theme).prop("checked", true);
+      update_theme(theme);
+  });
+  // Function to switch CSS theme
+  function update_theme(theme) {
 
-        //uncheck all radio buttons and select only current one
-        $(".theme-switcher input:checked").prop("checked", false);
-        $(".theme-switcher #theme-" + theme).prop("checked", true);
+    // Switch the stylesheet
+    var newlink = "/assets/css/nf-core-" + theme + ".css";
+    $("#theme-stylesheet").attr("href", newlink);
 
-        // Switch the stylesheet
-        var newlink = '/assets/css/nf-core-' + theme + '.css';
-        $('#theme-stylesheet').attr('href', newlink);
-
-        // Switch any images
-        $('.darkmode-image').each(function () {
-            var old_imgdir = (theme == "dark") ? "contributors-colour" : "contributors-white";
-            var new_imgdir = (theme == "dark") ? "contributors-white" : "contributors-colour";
-            $(this).attr('src', $(this).attr('src').replace(old_imgdir, new_imgdir));
-        });
-
-        // Set a cookie to remember
-        document.cookie = 'nfcoretheme=' + theme + '; expires=Thu, 2 Dec 2032 12:00:00 UTC; path=/';
+    // Switch any images
+    $(".darkmode-image").each(function () {
+        var old_imgdir =
+            theme == "dark" ? "contributors-colour" : "contributors-white";
+        var new_imgdir =
+            theme == "dark" ? "contributors-white" : "contributors-colour";
+        $(this).attr("src", $(this).attr("src").replace(old_imgdir, new_imgdir));
     });
 
-    // Override the .contains() filter to be case insenstive
-    $.expr[":"].contains = $.expr.createPseudo(function (arg) {
-        return function (elem) {
-            return $(elem).text().toUpperCase().indexOf(arg.toUpperCase()) >= 0;
-        };
-    });
+    // Set a cookie to remember
+    document.cookie =
+        "nfcoretheme=" + theme + "; expires=Thu, 2 Dec 2032 12:00:00 UTC; path=/";
+  }
+  // Override the .contains() filter to be case insenstive
+  $.expr[":"].contains = $.expr.createPseudo(function (arg) {
+    return function (elem) {
+      return $(elem).text().toUpperCase().indexOf(arg.toUpperCase()) >= 0;
+    };
+  });
 
-    // Homepage video switcher
-    $('.video-chooser a').click(function (e) {
-        if ($('#nf-core-video').is(':visible')) {
+  // Homepage video switcher
+    $(".video-chooser a").click(function (e) {
+        if ($("#nf-core-video").is(":visible")) {
             e.preventDefault();
-            $('.video-chooser a').removeClass('active');
-            $(this).addClass('active');
-            $('#nf-core-video').attr('src', $(this).data('src'));
+            $(".video-chooser a").removeClass("active");
+            $(this).addClass("active");
+            $("#nf-core-video").attr("src", $(this).data("src"));
         }
     });
 
-    // Homepage contributor images fading in and out
-    var h_contrib_imgs = $('.homepage_contrib_logos a');
-    if (h_contrib_imgs.length > 0) {
-        setTimeout(function () { switch_contrib_img(); }, 2000);
-    }
-    function switch_contrib_img() {
-        // Reset if all images have been shown
-        if ($('.homepage_contrib_logos a:hidden:not(.contrib_shown)').length == 0) {
-            $('.homepage_contrib_logos a').removeClass('contrib_shown');
-            $('.homepage_contrib_logos a:visible').addClass('contrib_shown');
-        }
-
-        // Get random seeds for images to fade in and out
-        var vis_imgs = $('.homepage_contrib_logos a:visible');
-        var img_out_idx = Math.floor(Math.random() * vis_imgs.length);
-
-        var hidden_imgs = $('.homepage_contrib_logos a:hidden:not(.contrib_shown)');
-        var img_in_idx = Math.floor(Math.random() * hidden_imgs.length);
-
-        // Label with a class
-        hidden_imgs.eq(img_in_idx).addClass('contrib_fade_in contrib_shown');
-        vis_imgs.eq(img_out_idx).addClass('contrib_fade_out');
-
-        // Move image to be faded in next to the one to be faded out
-        hidden_imgs.eq(img_in_idx).detach().insertAfter(vis_imgs.eq(img_out_idx));
-
-        // Fade images in and out
-        $('.contrib_fade_in').fadeIn();
-        $('.contrib_fade_out').hide();
-
-        // Clear labels
-        $('.homepage_contrib_logos a').removeClass('contrib_fade_in contrib_fade_out');
-
-        // Run this again in 2 seconds
-        setTimeout(function () { switch_contrib_img(); }, 3000);
+  // Homepage contributor images fading in and out
+  var h_contrib_imgs = $(".homepage_contrib_logos a");
+  if (h_contrib_imgs.length > 0) {
+    setTimeout(function () {
+      switch_contrib_img();
+    }, 2000);
+  }
+  function switch_contrib_img() {
+    // Reset if all images have been shown
+    if ($(".homepage_contrib_logos a:hidden:not(.contrib_shown)").length == 0) {
+        $(".homepage_contrib_logos a").removeClass("contrib_shown");
+        $(".homepage_contrib_logos a:visible").addClass("contrib_shown");
     }
 
-    // Filter pipelines with text
-    function filter_pipelines_text(ftext) {
-        $('.pipelines-container .pipeline:contains("' + ftext + '")').parent('.col').show();
-        $('.pipelines-container .pipeline:not(:contains("' + ftext + '"))').parent('.col').hide();
-        if ($('.pipelines-container .pipeline:visible').length == 0) { $('.no-pipelines').show(); }
-        else { $('.no-pipelines').hide(); }
+    // Get random seeds for images to fade in and out
+    var vis_imgs = $(".homepage_contrib_logos a:visible");
+    var img_out_idx = Math.floor(Math.random() * vis_imgs.length);
+
+    var hidden_imgs = $(".homepage_contrib_logos a:hidden:not(.contrib_shown)");
+    var img_in_idx = Math.floor(Math.random() * hidden_imgs.length);
+
+    // Label with a class
+    hidden_imgs.eq(img_in_idx).addClass("contrib_fade_in contrib_shown");
+    vis_imgs.eq(img_out_idx).addClass("contrib_fade_out");
+
+    // Move image to be faded in next to the one to be faded out
+    hidden_imgs.eq(img_in_idx).detach().insertAfter(vis_imgs.eq(img_out_idx));
+
+    // Fade images in and out
+    $(".contrib_fade_in").fadeIn();
+    $(".contrib_fade_out").hide();
+
+    // Clear labels
+    $(".homepage_contrib_logos a").removeClass(
+      "contrib_fade_in contrib_fade_out"
+    );
+
+    // Run this again in 2 seconds
+    setTimeout(function () {
+      switch_contrib_img();
+    }, 3000);
+  }
+
+  // Filter pipelines with text
+  function filter_pipelines_text(ftext) {
+    $('.pipelines-container .pipeline:contains("' + ftext + '")')
+      .parent(".col")
+      .show();
+    $('.pipelines-container .pipeline:not(:contains("' + ftext + '"))')
+      .parent(".col")
+      .hide();
+    if ($(".pipelines-container .pipeline:visible").length == 0) {
+      $(".no-pipelines").show();
+    } else {
+      $(".no-pipelines").hide();
     }
-    // page load
-    if ($('.pipelines-toolbar .pipeline-filters input').val()) {
-        var ftext = $('.pipelines-toolbar .pipeline-filters input').val();
-        filter_pipelines_text(ftext);
-        $('.pipelines-toolbar .pipeline-filters input').addClass('active');
+  }
+  // page load
+  if ($(".pipelines-toolbar .pipeline-filters input").val()) {
+    var ftext = $(".pipelines-toolbar .pipeline-filters input").val();
+    filter_pipelines_text(ftext);
+    $(".pipelines-toolbar .pipeline-filters input").addClass("active");
+  }
+  // onchange
+  $(".pipelines-toolbar .pipeline-filters input").keyup(function () {
+    var ftext = $(".pipelines-toolbar .pipeline-filters input").val();
+    filter_pipelines_text(ftext);
+    if ($(".pipelines-toolbar .pipeline-filters input").val()) {
+      $(".pipelines-toolbar .pipeline-filters input").addClass("active");
+    } else {
+      $(".pipelines-toolbar .pipeline-filters input").removeClass("active");
     }
-    // onchange
-    $('.pipelines-toolbar .pipeline-filters input').keyup(function () {
-        var ftext = $('.pipelines-toolbar .pipeline-filters input').val();
-        filter_pipelines_text(ftext);
-        if ($('.pipelines-toolbar .pipeline-filters input').val()) {
-            $('.pipelines-toolbar .pipeline-filters input').addClass('active');
-        } else {
-            $('.pipelines-toolbar .pipeline-filters input').removeClass('active');
-        }
+  });
+  // Filter pipelines with buttons
+  $(".pipelines-toolbar .pipeline-filters button").click(function () {
+    $(this).blur().toggleClass("active");
+    var showclasses = [];
+    $(".pipelines-toolbar .pipeline-filters button.active").each(function () {
+      showclasses.push($(this).data("bsTarget"));
     });
-    // Filter pipelines with buttons
-    $('.pipelines-toolbar .pipeline-filters button').click(function () {
-        $(this).blur().toggleClass('active');
-        var showclasses = [];
-        $('.pipelines-toolbar .pipeline-filters button.active').each(function () {
-            showclasses.push($(this).data('bsTarget'));
-        });
-        $('.pipelines-container .pipeline').filter(showclasses.join(', ')).parent('.col').show();
-        $('.pipelines-container .pipeline').not(showclasses.join(', ')).parent('.col').hide();
-        if ($('.pipelines-container .pipeline:visible').length == 0) { $('.no-pipelines').show(); }
-        else { $('.no-pipelines').hide(); }
-    });
-    // Sort pipelines
-    $('.pipelines-toolbar .pipeline-sorts button').click(function () {
-        // Clicking sort a second time reverses the order
-        var reverse = 1;
-        if ($(this).hasClass('active') && $(this).hasClass('reverse')) {
-            var reverse = -1;
-            $(this).removeClass('reverse');
-        } else {
-            $('.pipelines-toolbar .pipeline-sorts button').removeClass('reverse');
-            $(this).addClass('reverse');
-        }
-        // Apply the active class to this button
-        $('.pipelines-toolbar .pipeline-sorts button').removeClass('active');
-        $(this).blur().addClass('active');
-        // Sort the pipeline cards
-        $pipelines = $('.pipelines-container .col')
-        if ($(this).text() == 'Alphabetical') {
-            $pipelines.sort(function (a, b) {
-                var an = $(a).find('.card-title .pipeline-name').text();
-                var bn = $(b).find('.card-title .pipeline-name').text();
-                if (an > bn) { return 1 * reverse; }
-                if (an < bn) { return -1 * reverse; }
-                return 0;
-            });
-        }
-        if ($(this).text() == 'Status') {
-            $pipelines.sort(function (a, b) {
-                var at = $(a).attr("class").match(/pipeline-[\w]*\b/)[0];
-                var bt = $(b).attr("class").match(/pipeline-[\w]*\b/)[0];
-                if (at == 'pipeline-released') { an = 3; }
-                if (at == 'pipeline-archived') { an = 2; }
-                if (at == 'pipeline-dev') { an = 1; }
-                if (bt == 'pipeline-released') { bn = 3; }
-                if (bt == 'pipeline-archived') { bn = 2; }
-                if (bt == 'pipeline-dev') { bn = 1; }
-                if (an > bn) { return -1 * reverse; }
-                if (an < bn) { return 1 * reverse; }
-                return 0;
-            });
-        }
-        if ($(this).text() == 'Stars') {
-            $pipelines.sort(function (a, b) {
-                var an = Number($(a).find('.stargazers').text().trim());
-                var bn = Number($(b).find('.stargazers').text().trim());
-                if (typeof an === "undefined" || isNaN(an)) { an = 0; }
-                if (typeof bn === "undefined" || isNaN(bn)) { bn = 0; }
-                if (an > bn) { return -1 * reverse; }
-                if (an < bn) { return 1 * reverse; }
-                return 0;
-            });
-        }
-        if ($(this).text() == 'Last Release') {
-            $pipelines.sort(function (a, b) {
-                var an = $(a).find('.publish-date').data('pubdate');
-                var bn = $(b).find('.publish-date').data('pubdate');
-                if (typeof an === "undefined") { an = 0; }
-                if (typeof bn === "undefined") { bn = 0; }
-                if (an > bn) { return -1 * reverse; }
-                if (an < bn) { return 1 * reverse; }
-                return 0;
-            });
-        }
-        $pipelines.detach().appendTo($('.pipelines-container'));
-    });
-    // Change pipelines display type
-    $('.display-btn').click(function () {
-        $('.display-btn').removeClass('active');
-        $(this).addClass('active');
-        var dtype = $(this).data('dtype');
-        if (dtype == 'list' || dtype == 'blocks') {
-            $('.pipelines-container').
-                removeClass('pipelines-container-blocks pipelines-container-list').
-                addClass('pipelines-container-' + dtype).
-                removeClass('row-cols-md-2 g-4');
-            if(dtype=== 'blocks'){
-                $(".pipelines-container").addClass("row-cols-md-2 g-4");
-            }
-
-        }
-    });
-
-    // Make the stats tables sortable
-    if ($(".pipeline-stats-table").length > 0) {
-        $(".pipeline-stats-table").tablesorter();
+    $(".pipelines-container .pipeline")
+      .filter(showclasses.join(", "))
+      .parent(".col")
+      .show();
+    $(".pipelines-container .pipeline")
+      .not(showclasses.join(", "))
+      .parent(".col")
+      .hide();
+    if ($(".pipelines-container .pipeline:visible").length == 0) {
+      $(".no-pipelines").show();
+    } else {
+      $(".no-pipelines").hide();
     }
-
-    // Pipeline page version number dropdown
-    $('#version_select').on('change', function () {
-        document.location.href = $(this).val();
-    })
-
-    //copy text to clipboard
-    $('.toast').toast();
-    $('.copy-txt').on('click', function () {
-        var target = $(this).data('bsTarget');
-        var target_id = '#' + target;
-        $(target_id).trigger( 'select' );
-        document.execCommand('copy');
-        $(target_id).trigger('blur');
-        $('#pipeline_sidebar_cmd_copied').toast('show');
-    })
-    if (window.location.hash & $('.param-docs').length > 0) {
-        scroll_to($(window.location.hash), 0);
+  });
+  // Sort pipelines
+  $(".pipelines-toolbar .pipeline-sorts button").click(function () {
+    // Clicking sort a second time reverses the order
+    var reverse = 1;
+    if ($(this).hasClass("active") && $(this).hasClass("reverse")) {
+      var reverse = -1;
+      $(this).removeClass("reverse");
+    } else {
+      $(".pipelines-toolbar .pipeline-sorts button").removeClass("reverse");
+      $(this).addClass("reverse");
     }
-    // Page-scroll links
-    $('body').on('click', '.scroll_to_link', function (e) {
-        e.preventDefault();
-        var current_href = $(this).attr('href')
-        history.replaceState(null, '', current_href); // add href to url
-        scroll_to($(current_href), 0);
-    });
-
-    if($('details>summary:contains("Video transcript")').length > 0){
-        $('details>summary:contains("Video transcript")')
-            .parents("details")
-            .before(
-            '<div class="ratio ratio-16x9"><div id="video-placeholder"></div></div>'
-            );
-    } else if ($(".rendered-markdown").length > 0 && typeof youtube_embed!=='undefined' && youtube_embed) {
-        $(".rendered-markdown").append('<div class="ratio ratio-16x9"><div id="video-placeholder"></div></div>');
-    }
-
-    // Expand all details on page
-    $(".expand-details").on('click',function(){
-        // if all details are already open, close them, else open all
-        if ($("details[open]").length === $("details").length){
-            $("details[open]").removeAttr("open");
-        }else{
-            $("details:not([open])").attr("open", "");
+    // Apply the active class to this button
+    $(".pipelines-toolbar .pipeline-sorts button").removeClass("active");
+    $(this).blur().addClass("active");
+    // Sort the pipeline cards
+    $pipelines = $(".pipelines-container .col");
+    if ($(this).text() == "Alphabetical") {
+      $pipelines.sort(function (a, b) {
+        var an = $(a).find(".card-title .pipeline-name").text();
+        var bn = $(b).find(".card-title .pipeline-name").text();
+        if (an > bn) {
+          return 1 * reverse;
         }
-        // refresh scrollspy to recalculate offsets, still not working 100% of the time...
-        var dataSpyList = [].slice.call(
-            document.querySelectorAll('[data-bs-spy="scroll"]')
-        );
-        dataSpyList.forEach(function (dataSpyEl) {
-            bootstrap.ScrollSpy.getInstance(dataSpyEl).refresh();
-        });
+        if (an < bn) {
+          return -1 * reverse;
+        }
+        return 0;
+      });
+    }
+    if ($(this).text() == "Status") {
+      $pipelines.sort(function (a, b) {
+        var at = $(a)
+          .attr("class")
+          .match(/pipeline-[\w]*\b/)[0];
+        var bt = $(b)
+          .attr("class")
+          .match(/pipeline-[\w]*\b/)[0];
+        if (at == "pipeline-released") {
+          an = 3;
+        }
+        if (at == "pipeline-archived") {
+          an = 2;
+        }
+        if (at == "pipeline-dev") {
+          an = 1;
+        }
+        if (bt == "pipeline-released") {
+          bn = 3;
+        }
+        if (bt == "pipeline-archived") {
+          bn = 2;
+        }
+        if (bt == "pipeline-dev") {
+          bn = 1;
+        }
+        if (an > bn) {
+          return -1 * reverse;
+        }
+        if (an < bn) {
+          return 1 * reverse;
+        }
+        return 0;
+      });
+    }
+    if ($(this).text() == "Stars") {
+      $pipelines.sort(function (a, b) {
+        var an = Number($(a).find(".stargazers").text().trim());
+        var bn = Number($(b).find(".stargazers").text().trim());
+        if (typeof an === "undefined" || isNaN(an)) {
+          an = 0;
+        }
+        if (typeof bn === "undefined" || isNaN(bn)) {
+          bn = 0;
+        }
+        if (an > bn) {
+          return -1 * reverse;
+        }
+        if (an < bn) {
+          return 1 * reverse;
+        }
+        return 0;
+      });
+    }
+    if ($(this).text() == "Last Release") {
+      $pipelines.sort(function (a, b) {
+        var an = $(a).find(".publish-date").data("pubdate");
+        var bn = $(b).find(".publish-date").data("pubdate");
+        if (typeof an === "undefined") {
+          an = 0;
+        }
+        if (typeof bn === "undefined") {
+          bn = 0;
+        }
+        if (an > bn) {
+          return -1 * reverse;
+        }
+        if (an < bn) {
+          return 1 * reverse;
+        }
+        return 0;
+      });
+    }
+    $pipelines.detach().appendTo($(".pipelines-container"));
+  });
+  // Change pipelines display type
+  $(".display-btn").click(function () {
+    $(".display-btn").removeClass("active");
+    $(this).addClass("active");
+    var dtype = $(this).data("dtype");
+    if (dtype == "list" || dtype == "blocks") {
+      $(".pipelines-container")
+        .removeClass("pipelines-container-blocks pipelines-container-list")
+        .addClass("pipelines-container-" + dtype)
+        .removeClass("row-cols-md-2 g-4");
+      if (dtype === "blocks") {
+        $(".pipelines-container").addClass("row-cols-md-2 g-4");
+      }
+    }
+  });
 
+  // Make the stats tables sortable
+  if ($(".pipeline-stats-table").length > 0) {
+    $(".pipeline-stats-table").tablesorter();
+  }
 
-    })
+  // Pipeline page version number dropdown
+  $("#version_select").on("change", function () {
+    document.location.href = $(this).val();
+  });
+
+  //copy text to clipboard
+  $(".toast").toast();
+  $(".copy-txt").on("click", function () {
+    var target = $(this).data("bsTarget");
+    var target_id = "#" + target;
+    $(target_id).trigger("select");
+    document.execCommand("copy");
+    $(target_id).trigger("blur");
+    $("#pipeline_sidebar_cmd_copied").toast("show");
+  });
+  if (window.location.hash & ($(".param-docs").length > 0)) {
+    scroll_to($(window.location.hash), 0);
+  }
+  // Page-scroll links
+  $("body").on("click", ".scroll_to_link", function (e) {
+    e.preventDefault();
+    var current_href = $(this).attr("href");
+    history.replaceState(null, "", current_href); // add href to url
+    scroll_to($(current_href), 0);
+  });
+
+  if ($('details>summary:contains("Video transcript")').length > 0) {
+    $('details>summary:contains("Video transcript")')
+      .parents("details")
+      .before(
+        '<div class="ratio ratio-16x9"><div id="video-placeholder"></div></div>'
+      );
+  } else if (
+    $(".rendered-markdown").length > 0 &&
+    typeof youtube_embed !== "undefined" &&
+    youtube_embed
+  ) {
+    $(".rendered-markdown").append(
+      '<div class="ratio ratio-16x9"><div id="video-placeholder"></div></div>'
+    );
+  }
+
+  // Expand all details on page
+  $(".expand-details").on("click", function () {
+    // if all details are already open, close them, else open all
+    if ($("details[open]").length === $("details").length) {
+      $("details[open]").removeAttr("open");
+    } else {
+      $("details:not([open])").attr("open", "");
+    }
+    // refresh scrollspy to recalculate offsets, still not working 100% of the time...
+    var dataSpyList = [].slice.call(
+      document.querySelectorAll('[data-bs-spy="scroll"]')
+    );
+    dataSpyList.forEach(function (dataSpyEl) {
+      bootstrap.ScrollSpy.getInstance(dataSpyEl).refresh();
+    });
+  });
 });
 
 function scroll_to(target_el, offset) {

--- a/public_html/assets/scss/_nf-core.scss
+++ b/public_html/assets/scss/_nf-core.scss
@@ -10,10 +10,6 @@ $blockquote-color: shift-color($info, $alert-color-scale);
 
 
 // general classes
-.hide-light {
-    display: none;
-}
-
 body {
   font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
   position: relative;

--- a/public_html/assets/scss/nf-core-light.scss
+++ b/public_html/assets/scss/nf-core-light.scss
@@ -10,3 +10,10 @@
 // Import custom styling for nf-core
 //
 @import "nf-core";
+
+.hide-light {
+    display: none;
+}
+.hide-dark {
+    display: inherit;
+}

--- a/public_html/events.php
+++ b/public_html/events.php
@@ -85,10 +85,10 @@ function print_events($events, $is_past_event)
             echo '<p>' . nl2br($event['description']) . '</p>';
           } ?>
           <div class="btn-group" role="group">
-            <a type="button" href="<?php echo $event['url']; ?>" class="btn btn-outline-success">
+            <a href="<?php echo $event['url']; ?>" class="btn btn-outline-success">
               See details
             </a>
-            <?php echo create_event_download_button($event, "btn-outline-success");?>
+            <?php echo create_event_download_button($event, "btn-outline-success"); ?>
           </div>
         <?php else : ?>
           <h6 class="small text-muted mb-0">


### PR DESCRIPTION
I ran prettier over `nf-core.js` which unfortunately makes the diff not helpful. The relevant lines are 19-60 (writing the theme cookie on load and listening to OS theme changes).

I think we should also find a better solution for `nf-core-auto.scss`, which imports initially (without the cookie) both css files, if your OS theme is set to dark mode.