### PR TITLE
Adding GitPod button to nf-core usage tutorial

### DIFF
--- a/markdown/usage/tutorials/nf_core_usage_tutorial.md
+++ b/markdown/usage/tutorials/nf_core_usage_tutorial.md
@@ -19,12 +19,9 @@ subtitle: Tutorial covering the basics of using nf-core pipelines.
 
 **[Click here to download the slides associated with this tutorial.](/assets/markdown_assets/usage/nf_core_tutorial/nf-core-tutorial-usage.pdf)**
 
-
 You can run the commands of this tutorial on [GitPod](https://www.gitpod.io/) and skip the installation steps. In this case, use the following button:
 
-
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#url=nf-co+re[usage[tutorials[nf_core_usage_tutorial/https://github.com/nf-core/nf-co.re/blob/gitpod_config_training/)
-
 
 #### Overview
 
@@ -137,7 +134,6 @@ The nf-core pipelines currently available and under development are also listed 
 - Use `nf-core list` to see if the pipeline you pulled is up to date
 - Filter pipelines for those that work with RNA
 - Save these pipeline details to a JSON file
-
 
 ## Running nf-core pipelines
 
@@ -268,7 +264,6 @@ To know more about running pipelines offline you can check the [pipeline configu
 - In a new directory, run the _nf-core/rnaseq_ pipeline with the provided test data
 - Try launching the RNA pipeline using the `nf-core launch` command
 - Download the _nf-core/rnaseq_ pipeline for offline use using the `nf-core download` command
-
 
 ## Troubleshooting nf-core pipelines
 


### PR DESCRIPTION
This PR simply adds a link that spins a GitPod environment, which automatically opens up the nf-co.re tutorial page on top of a terminal.
The environment is using the nf-core/gitpod image, and is configure to run nf-core tools and nextflow.
The button works if the branch `gitpod_config_training` in nf-co.re exists, since it has to store the correct config files.

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1094"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

relates to [#68](https://github.com/carpentries-incubator/workflows-nextflow/issues/68)