### PR TITLE
updating youtube info and removing zoom links for past bytesize talks

### DIFF
--- a/markdown/events/2022/bytesize-31-nf-core-dualrnaseq.md
+++ b/markdown/events/2022/bytesize-31-nf-core-dualrnaseq.md
@@ -7,8 +7,6 @@ start_time: '13:00 CET'
 end_date: '2022-02-01'
 end_time: '13:30 CET'
 youtube_embed: https://youtu.be/-J3Cbetk8Pk
-location_url:
-  - https://youtu.be/-J3Cbetk8Pk
 ---
 
 # nf-core/bytesize

--- a/markdown/events/2022/bytesize-32-nf-core-rnaseq.md
+++ b/markdown/events/2022/bytesize-32-nf-core-rnaseq.md
@@ -7,8 +7,6 @@ start_time: '13:00 CET'
 end_date: '2022-02-08'
 end_time: '13:30 CET'
 youtube_embed: https://youtu.be/qMuUt8oVhHw
-location_url:
-  - https://youtu.be/qMuUt8oVhHw
 ---
 
 # nf-core/bytesize

--- a/markdown/events/2022/bytesize-33-tower-cli.md
+++ b/markdown/events/2022/bytesize-33-tower-cli.md
@@ -7,8 +7,6 @@ start_time: '13:00 CET'
 end_date: '2022-02-15'
 end_time: '13:30 CET'
 youtube_embed: https://youtu.be/MggFf15vGCw
-location_url:
-  - https://zoom.us/j/94352451216
 ---
 
 # nf-core/bytesize

--- a/markdown/events/2022/bytesize-34-dsl2-syntax.md
+++ b/markdown/events/2022/bytesize-34-dsl2-syntax.md
@@ -7,8 +7,6 @@ start_time: '13:00 CET'
 end_date: '2022-02-22'
 end_time: '13:30 CET'
 youtube_embed: https://youtu.be/17NqUsh73BU
-location_url:
-  - https://zoom.us/j/94352451216
 ---
 
 # nf-core/bytesize

--- a/markdown/events/2022/bytesize-35-debugging-pipeline.md
+++ b/markdown/events/2022/bytesize-35-debugging-pipeline.md
@@ -7,8 +7,6 @@ start_time: '13:00 CET'
 end_date: '2022-03-01'
 end_time: '13:30 CET'
 youtube_embed: https://youtu.be/z9n2F4ByIkY
-location_url:
-  - https://zoom.us/j/94352451216
 ---
 
 # nf-core/bytesize

--- a/markdown/events/2022/bytesize-36-multiqc.md
+++ b/markdown/events/2022/bytesize-36-multiqc.md
@@ -7,8 +7,6 @@ start_time: '13:00 CET'
 end_date: '2022-03-08'
 end_time: '13:30 CET'
 youtube_embed: https://www.youtube.com/watch?v=a3_IYSMrKAk
-location_url:
-  - https://zoom.us/j/94352451216
 ---
 
 # nf-core/bytesize

--- a/markdown/events/2022/bytesize-37-gathertown.md
+++ b/markdown/events/2022/bytesize-37-gathertown.md
@@ -7,8 +7,6 @@ start_time: '13:00 CET'
 end_date: '2022-03-15'
 end_time: '13:30 CET'
 youtube_embed: https://www.youtube.com/watch?v=nRY1_FvL7Pk
-location_url:
-  - https://zoom.us/j/94352451216
 ---
 
 # nf-core/bytesize

--- a/markdown/events/2022/bytesize-40-software-packaging.md
+++ b/markdown/events/2022/bytesize-40-software-packaging.md
@@ -6,8 +6,7 @@ start_date: '2022-04-05'
 start_time: '13:00 CEST'
 end_date: '2022-04-05'
 end_time: '13:30 CEST'
-location_url:
-  - https://zoom.us/j/94352451216
+youtube_embedded: https://www.youtube.com/watch?v=0ZpcYtKDZrU
 ---
 
 # nf-core/bytesize

--- a/markdown/events/2022/bytesize-41-prettier.md
+++ b/markdown/events/2022/bytesize-41-prettier.md
@@ -6,8 +6,7 @@ start_date: '2022-04-12'
 start_time: '13:00 CEST'
 end_date: '2022-04-12'
 end_time: '13:30 CEST'
-location_url:
-  - https://zoom.us/j/94352451216
+youtube_embedded: https://www.youtube.com/watch?v=ZO4lSma3OA8
 ---
 
 # nf-core/bytesize

--- a/markdown/events/2022/bytesize-survey_results.md
+++ b/markdown/events/2022/bytesize-survey_results.md
@@ -6,8 +6,7 @@ start_date: '2022-05-24'
 start_time: '13:00 CEST'
 end_date: '2022-05-24'
 end_time: '13:30 CEST'
-location_url:
-  - https://kth-se.zoom.us/j/68390542812
+youtube_embedded: https://youtu.be/DYdPNPVa4wc
 ---
 
 # nf-core/bytesize


### PR DESCRIPTION
old zoom links, also from before my time were removed. Youtube links to previous talks were added

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1183"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

