### PR TITLE
Add missing healx logo extension

### DIFF
--- a/nf-core-contributors.yaml
+++ b/nf-core-contributors.yaml
@@ -930,7 +930,7 @@ contributors:
     address: Charter House, 66-68 Hills Rd, Cambridge, CB2 1LA, UK
     url: https://healx.ai/
     affiliation: Digital Biology
-    image_fn: HEALXLOGO
+    image_fn: HEALXLOGO.svg
     contact: Jonathan Manning
     contact_email: jonathan.manning@healx.io
     contact_github: pinin4fjords


### PR DESCRIPTION
I managed to omit the logo extension in https://github.com/nf-core/nf-co.re/pull/1546, fixing here.

<a href="https://gitpod.io/#https://github.com/nf-core/nf-co.re/pull/1549"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

