### PR TITLE
fixed link to github modules issue. 'module' > 'modules'

### DIFF
--- a/src/pages/modules/[...moduleslug].astro
+++ b/src/pages/modules/[...moduleslug].astro
@@ -81,7 +81,7 @@ function truncatURLs(url) {
 
         <div class="col-none col-md-3">
             <SidebarStats
-                component_type={'module'}
+                component_type={'modules'}
                 contributors={module.meta.authors}
                 included_pipelines={module.pipelines}
                 included_subworkflows={module.subworkflows}


### PR DESCRIPTION
 The 'Open an issue on Github' link in each modules sidebar is giving a 404. It is as simple as the component_type on this line being misspelled as 'module' instead of 'modules'. 
 
 I saw the list of small issues on Slack and figured I might as well try to come up with a solution to this one. 
 
 This would close the issue I made not long ago. Closes #1860