### PR TITLE
Event header: Fix typo in end time display

### DIFF
--- a/src/components/event/EventHeader.astro
+++ b/src/components/event/EventHeader.astro
@@ -10,7 +10,7 @@ const start = frontmatter.start?.toLocaleString('en-US', {
     minute: 'numeric',
     hour12: false,
 });
-const end = frontmatter.start?.toLocaleString('en-US', {
+const end = frontmatter.end?.toLocaleString('en-US', {
     year: 'numeric',
     month: 'long',
     day: 'numeric',


### PR DESCRIPTION
Events show the start time for both start and end:

![image](https://github.com/nf-core/website/assets/465550/c25fde17-e073-4a86-a6d4-8efe654c7bed)

This hopefully fixes that.