### PR TITLE
Make the governance page name badges better

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: 'v2.7.1'
+    rev: 'v3.0.2'
     hooks:
       - id: prettier
         additional_dependencies:

--- a/src/components/GitHubProfilePictureExtended.svelte
+++ b/src/components/GitHubProfilePictureExtended.svelte
@@ -13,13 +13,13 @@
 </script>
 
 <GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2 d-flex align-items-center"
+    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2 d-inline-flex align-items-center"
     image={'https://github.com/' + username + '.png'}
     name={username}
     circle={true}
     size={50}
 >
-    <div class={'ms-2 d-inline-block text-start d-flex flex-column align-items-center px-2 ' + extra_classes}>
+    <div class={'ms-2 d-inline-block text-start d-flex flex-column align-items-left px-2 ' + extra_classes}>
         <slot />
         {@html affiliation_str}
     </div>

--- a/src/components/GitHubProfilePictureExtended.svelte
+++ b/src/components/GitHubProfilePictureExtended.svelte
@@ -19,7 +19,7 @@
     circle={true}
     size={50}
 >
-    <div class={'ms-2 d-inline-block text-start d-flex flex-column align-items-left px-2 ' + extra_classes}>
+    <div class={'ms-2 d-inline-block text-start d-flex flex-column px-2 ' + extra_classes}>
         <slot />
         {@html affiliation_str}
     </div>

--- a/src/components/GitHubProfilePictureExtended.svelte
+++ b/src/components/GitHubProfilePictureExtended.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+    // Import GitHubProfilePicture.svelte component
+    import GitHubProfilePicture from './GitHubProfilePicture.svelte';
+
+    export let username: string;
+    export let affiliation: string = '';
+
+    const affiliation_str =
+        affiliation.length > 0
+            ? `<div class="small"><abbr class="small d-inline-block text-truncate" data-bs-placement="bottom" data-bs-toggle="tooltip" title="${affiliation}" style="max-width: 12rem;">${affiliation}</abbr></div>`
+            : '';
+    const extra_classes = affiliation.length > 0 ? 'small' : '';
+</script>
+
+<GitHubProfilePicture
+    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
+    image={'https://github.com/' + username + '.png'}
+    name={username}
+    circle={true}
+    size={40}
+>
+    <div class={'ms-2 d-inline-block text-start ' + extra_classes}>
+        <slot />
+        {@html affiliation_str}
+    </div>
+</GitHubProfilePicture>

--- a/src/components/GitHubProfilePictureExtended.svelte
+++ b/src/components/GitHubProfilePictureExtended.svelte
@@ -13,13 +13,13 @@
 </script>
 
 <GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
+    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2 d-flex align-items-center"
     image={'https://github.com/' + username + '.png'}
     name={username}
     circle={true}
-    size={40}
+    size={50}
 >
-    <div class={'ms-2 d-inline-block text-start ' + extra_classes}>
+    <div class={'ms-2 d-inline-block text-start d-flex flex-column align-items-center px-2 ' + extra_classes}>
         <slot />
         {@html affiliation_str}
     </div>

--- a/src/components/sidebar/SidebarToc.svelte
+++ b/src/components/sidebar/SidebarToc.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { currentHeading, showHidden } from '@components/store';
-    import { sub } from 'date-fns';
     import { onMount } from 'svelte';
 
     export let headings: {
@@ -10,6 +9,11 @@
         fa_icon?: string;
         hidden?: boolean;
     }[];
+
+    export let maxHeadingDepth: number = 4;
+
+    // filter out headings that are higher than max_heading_depth
+    headings = headings.filter((h) => h.depth <= maxHeadingDepth);
 
     const min_heading_depth = Math.min(...headings.map((h) => h.depth));
     // make margin classes from min to max heading depth

--- a/src/content/about/governance.mdx
+++ b/src/content/about/governance.mdx
@@ -3,7 +3,7 @@ title: Governance
 description: Governance of the nf-core community
 ---
 
-import GitHubProfilePicture from '@components/GitHubProfilePicture.svelte';
+import Profile from '@components/GitHubProfilePictureExtended.svelte'
 
 ## Governance
 
@@ -41,61 +41,13 @@ The steering committee will meet regularly to discuss the project, funding and p
 
 **Members**
 
-<GitHubProfilePicture
-    name="apeltzer"
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/apeltzer.png"
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Alexander Peltzer</span>
-</GitHubProfilePicture>
+<Profile username='apeltzer'>Alexander Peltzer</Profile>
 <a class="btn btn-light rounded-pill mb-2 p-2">Ellen Sherwood</a>
-<GitHubProfilePicture
-    name="evanfloden"
-    image="https://github.com/evanfloden.png"
-    circle={true}
-    size={40}
-    wrapperClasses={'btn btn-light rounded-pill mb-2 p-0 pe-2'}
->
-    <span class="ms-2">Evan Floden</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    name="ggabernet"
-    image="https://github.com/ggabernet.png"
-    circle={true}
-    size={40}
-    wrapperClasses={'btn btn-light rounded-pill mb-2 p-0 pe-2'}
->
-    <span class="ms-2">Gisela Gabernet</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    name="drpatelh"
-    image="https://github.com/drpatelh.png"
-    circle={true}
-    size={40}
-    wrapperClasses={'btn btn-light rounded-pill mb-2 p-0 pe-2'}
->
-    <span class="ms-2">Harshil Patel</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    name="ewels"
-    image="https://github.com/ewels.png"
-    circle={true}
-    size={40}
-    wrapperClasses={'btn btn-light rounded-pill mb-2 p-0 pe-2'}
->
-    <span class="ms-2">Phil Ewels</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    name="naepfel"
-    image="https://github.com/naepfel.png"
-    circle={true}
-    size={40}
-    wrapperClasses={'btn btn-light rounded-pill mb-2 p-0 pe-2'}
->
-    <span class="ms-2">Sven Nahnsen</span>
-</GitHubProfilePicture>
+<Profile username='evanfloden'>Evan Floden</Profile>
+<Profile username='ggabernet'>Gisela Gabernet</Profile>
+<Profile username='drpatelh'>Harshil Patel</Profile>
+<Profile username='ewels'>Phil Ewels</Profile>
+<Profile username='naepfel'>Sven Nahnsen</Profile>
 
 #### Core team
 
@@ -117,171 +69,27 @@ Core team members will appear as organization members on the GitHub organization
 
 **Members**
 
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/christopher-hakkaart.png"
-    name={'christopher-hakkaart'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Chris Hakkaart</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/drpatelh.png"
-    name={'drpatelh'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Harshil Patel</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/ewels.png"
-    name={'ewels'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Phil Ewels</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/FranBonath.png"
-    name={'FranBonath'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Franziska Bonath</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/FriederikeHanssen.png"
-    name={'FriederikeHanssen'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Friederike Hanssen</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/ggabernet.png"
-    name={'ggabernet'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Gisela Gabernet</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/jfy133.png"
-    name={'jfy133'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">James A. Fellows Yates</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/JoseEspinosa.png"
-    name={'JoseEspinosa'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Jose Espinosa-Carrasco</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/mashehu.png"
-    name={'mashehu'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Matthias Hörtenhuber</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/MaxUlysse.png"
-    name={'MaxUlysse'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Maxime Garcia</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/mirpedrol.png"
-    name={'mirpedrol'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Júlia Mir Pedrol</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/mribeirodantas.png"
-    name={'mribeirodantas'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Marcel Ribeiro-Dantas</span>
-</GitHubProfilePicture>
+<Profile username='christopher-hakkaart'>Chris Hakkaart</Profile>
+<Profile username='drpatelh'>Harshil Patel</Profile>
+<Profile username='ewels'>Phil Ewels</Profile>
+<Profile username='FranBonath'>Franziska Bonath</Profile>
+<Profile username='FriederikeHanssen'>Friederike Hanssen</Profile>
+<Profile username='ggabernet'>Gisela Gabernet</Profile>
+<Profile username='jfy133'>James A. Fellows Yates</Profile>
+<Profile username='JoseEspinosa'>Jose Espinosa-Carrasco</Profile>
+<Profile username='mashehu'>Matthias Hörtenhuber</Profile>
+<Profile username='MaxUlysse'>Maxime Garcia</Profile>
+<Profile username='mirpedrol'>Júlia Mir Pedrol</Profile>
+<Profile username='mribeirodantas'>Marcel Ribeiro-Dantas</Profile>
 
 **Core team alumni**
 
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/apeltzer.png"
-    name={'apeltzer'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Alexander Peltzer</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/alneberg.png"
-    name={'alneberg'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Johannes Alneberg </span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/KevinMenden.png"
-    name={'KevinMenden'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Kevin Menden</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/olgabot.png"
-    name={'olgabot'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Olga Botvinnik</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/renbot-bio.png"
-    name={'renbot-bio'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Renuka Kudva</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/sven1103.png"
-    name={'sven1103'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Sven F.</span>
-</GitHubProfilePicture>
+<Profile username='apeltzer'>Alexander Peltzer</Profile>
+<Profile username='alneberg'>Johannes Alneberg</Profile>
+<Profile username='KevinMenden'>Kevin Menden</Profile>
+<Profile username='olgabot'>Olga Botvinnik</Profile>
+<Profile username='renbot-bio'>Renuka Kudva</Profile>
+<Profile username='sven1103'>Sven F.</Profile>
 
 #### Safety
 
@@ -294,33 +102,9 @@ The safety team is not a part of the core team and can report directly to the st
 
 **Members**
 
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/ctuni.png"
-    name={'ctuni'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Cris Tuñí</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/heuermh.png"
-    name={'heuermh'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Michael Heuer</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/snafees.png"
-    name={'snafees'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Saba Nafees</span>
-</GitHubProfilePicture>
+<Profile username='ctuni'>Cris Tuñí</Profile>
+<Profile username='heuermh'>Michael Heuer</Profile>
+<Profile username='snafees'>Saba Nafees</Profile>
 
 **Responsibilities**
 
@@ -345,36 +129,12 @@ The infrastructure team will have administrator access to repositories.
 
 **Leads**
 
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/ewels.png"
-    name={'ewels'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Phil Ewels</span>
-</GitHubProfilePicture>
+<Profile username='ewels'>Phil Ewels</Profile>
 
 **Members**
 
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/mirpedrol.png"
-    name={'mirpedrol'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Júlia Mir Pedrol</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/mashehu.png"
-    name={'mashehu'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Matthias Hörtenhuber</span>
-</GitHubProfilePicture>
+<Profile username='mirpedrol'>Júlia Mir Pedrol</Profile>
+<Profile username='mashehu'>Matthias Hörtenhuber</Profile>
 
 #### Outreach
 
@@ -395,93 +155,21 @@ The outreach leads will have access to community social media and YouTube accoun
 
 **Leads**
 
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/christopher-hakkaart.png"
-    name={'christopher-hakkaart'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Chris Hakkaart</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/FranBonath.png"
-    name={'FranBonath'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Franziska Bonath</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/mribeirodantas.png"
-    name={'mribeirodantas'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Marcel Ribeiro-Dantas</span>
-</GitHubProfilePicture>
+<Profile username='christopher-hakkaart'>Chris Hakkaart</Profile>
+<Profile username='FranBonath'>Franziska Bonath</Profile>
+<Profile username='mribeirodantas'>Marcel Ribeiro-Dantas</Profile>
 
 **Members**
 
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/abhi18av.png"
-    name={'abhi18av'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Abhinav Sharma</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/Emiller88.png"
-    name={'Emiller88'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Edmund Miller</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/MaxUlysse.png"
-    name={'MaxUlysse'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Maxime Garcia</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/pcantalupo.png"
-    name={'pcantalupo'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Paul Cantalupo</span>
-</GitHubProfilePicture>
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/yuukiiwa.png"
-    name={'yuukiiwa'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Yuk Kei</span>
-</GitHubProfilePicture>
+<Profile username='abhi18av'>Abhinav Sharma</Profile>
+<Profile username='Emiller88'>Edmund Miller</Profile>
+<Profile username='MaxUlysse'>Maxime Garcia</Profile>
+<Profile username='pcantalupo'>Paul Cantalupo</Profile>
+<Profile username='yuukiiwa'>Yuk Kei</Profile>
 
 **Alumni**
 
-<GitHubProfilePicture
-    wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-    image="https://github.com/Xesus-Abalo.png"
-    name={'Xesus-Abalo'}
-    circle={true}
-    size={40}
->
-    <span class="ms-2">Xesús M. Abalo</span>
-</GitHubProfilePicture>
+<Profile username='Xesus-Abalo'>Xesús M. Abalo</Profile>
 
 #### Maintainers
 
@@ -503,296 +191,102 @@ nf-core maintainers will have write access to repositories.
 
 **Members**
 
-<ul>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/adamrtalbot.png"
-            name={'adamrtalbot'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Adam Talbot</span>
-        </GitHubProfilePicture>
-        (Nonacus)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/asp8200.png"
-            name={'asp8200'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Anders Sune Pedersen</span>
-        </GitHubProfilePicture>
-        (Danish National Genome Center)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/jemten.png"
-            name={'jemten'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Anders Jemt</span>
-        </GitHubProfilePicture>
-        (Science for Life Laboratory)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/christopher-mohr.png"
-            name={'christopher-mohr'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Christopher Mohr</span>
-        </GitHubProfilePicture>
-        (Boehringer Ingelheim)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/erikrikarddaniel.png"
-            name={'erikrikarddaniel'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Daniel Lundin</span>
-        </GitHubProfilePicture>
-        (Linnaeus University)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/Emiller88.png"
-            name={'Emiller88'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Edmund Miller</span>
-        </GitHubProfilePicture>
-        (University of Texas at Dallas & Element Biosciences)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/FriederikeHanssen.png"
-            name={'FriederikeHanssen'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Friederike Hanssen</span>
-        </GitHubProfilePicture>
-        (Quantitative Biology Center, QBiC, University of Tübingen)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/mirpedrol.png"
-            name={'mirpedrol'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Júlia Mir Pedrol</span>
-        </GitHubProfilePicture>
-        (Quantitative Biology Center, QBiC, University of Tübingen)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/ggabernet.png"
-            name={'ggabernet'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Gisela Gabernet</span>
-        </GitHubProfilePicture>
-        (Quantitative Biology Center, QBiC, University of Tübingen)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/drpatelh.png"
-            name={'drpatelh'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Harshil Patel</span>
-        </GitHubProfilePicture>
-        (Seqera Labs)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/jfy133.png"
-            name={'jfy133'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> James A. Fellows Yates</span>
-        </GitHubProfilePicture>
-        (Leibniz Institute for Natural Product Research and Infection Biology Hans Knöll Institute & Max Planck Institute - for Evolutionary Anthropology)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/jasmezz.png"
-            name={'jasmezz'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Jasmin Frangenberg</span>
-        </GitHubProfilePicture>
-        (Leibniz Institute for Natural Product Research and Infection Biology Hans Knöll Institute)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/pinin4fjords.png"
-            name={'pinin4fjords'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Jon Manning</span>
-        </GitHubProfilePicture>
-        (Healx Ltd)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/JoseEspinosa.png"
-            name={'JoseEspinosa'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Jose Espinosa-Carrasco</span>
-        </GitHubProfilePicture>
-        (Centre for Genomic Regulation)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/louperelo.png"
-            name={'louperelo'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Louisa Perelo</span>
-        </GitHubProfilePicture>
-        (Quantitative Biology Center, QBiC, University of Tübingen)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/matthdsm.png"
-            name={'matthdsm'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Matthias De Smet</span>
-        </GitHubProfilePicture>
-        (Center For Medical Genetics Ghent)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/mashehu.png"
-            name={'mashehu'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Matthias Hörtenhuber</span>
-        </GitHubProfilePicture>
-        (Science for Life Laboratory)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/maxulysse.png"
-            name={'maxulysse'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Maxime U. Garcia</span>
-        </GitHubProfilePicture>
-        (Seqera Labs)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/Midnighter.png"
-            name={'Midnighter'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Moritz E. Beber</span>
-        </GitHubProfilePicture>
-        (Unseen Bio ApS)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/nvnieuwk.png"
-            name={'nvnieuwk'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Nicolas Vannieuwkerke</span>
-        </GitHubProfilePicture>
-        (Center For Medical Genetics Ghent)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/ramprasadn.png"
-            name={'ramprasadn'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Ramprasad Neethiraj</span>
-        </GitHubProfilePicture>
-        (Science for Life Laboratory)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/robsyme.png"
-            name={'robsyme'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Rob Syme</span>
-        </GitHubProfilePicture>
-        (Seqera Labs)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/sppearce.png"
-            name={'sppearce'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Simon Pearce</span>
-        </GitHubProfilePicture>
-        (Cancer Research UK Manchester Institute)
-    </li>
-    <li>
-        <GitHubProfilePicture
-            wrapperClasses="btn btn-light rounded-pill mb-2 p-0 pe-2"
-            image="https://github.com/sofstam.png"
-            name={'sofstam'}
-            circle={true}
-            size={40}
-        >
-            <span class="ms-2"> Sofia Stamouli</span>
-        </GitHubProfilePicture>
-        (Karolinska Institute & Karolinska University Hospital)
-    </li>
-</ul>
+<Profile
+    username='adamrtalbot'
+    affiliation='Nonacus'
+>Adam Talbot</Profile>
+<Profile
+    username='asp8200'
+    affiliation='Danish National Genome Center'
+>Anders Sune Pedersen</Profile>
+<Profile
+    username='jemten'
+    affiliation='Science for Life Laboratory'
+>Anders Jemt</Profile>
+<Profile
+    username='christopher-mohr'
+    affiliation='Boehringer Ingelheim'
+>Christopher Mohr</Profile>
+<Profile
+    username='erikrikarddaniel'
+    affiliation='Linnaeus University'
+>Daniel Lundin</Profile>
+<Profile
+    username='Emiller88'
+    affiliation='University of Texas at Dallas & Element Biosciences'
+>Edmund Miller</Profile>
+<Profile
+    username='FriederikeHanssen'
+    affiliation='Quantitative Biology Center, QBiC, University of Tübingen'
+>Friederike Hanssen</Profile>
+<Profile
+    username='mirpedrol'
+    affiliation='Quantitative Biology Center, QBiC, University of Tübingen'
+>Júlia Mir Pedrol</Profile>
+<Profile
+    username='ggabernet'
+    affiliation='Quantitative Biology Center, QBiC, University of Tübingen'
+>Gisela Gabernet</Profile>
+<Profile
+    username='drpatelh'
+    affiliation='Seqera Labs'
+>Harshil Patel</Profile>
+<Profile
+    username='jfy133'
+    affiliation='Leibniz Institute for Natural Product Research and Infection Biology Hans Knöll Institute & Max Planck Institute - for Evolutionary Anthropology'
+>James A. Fellows Yates</Profile>
+<Profile
+    username='jasmezz'
+    affiliation='Leibniz Institute for Natural Product Research and Infection Biology Hans Knöll Institute'
+>Jasmin Frangenberg</Profile>
+<Profile
+    username='pinin4fjords'
+    affiliation='Healx Ltd'
+>Jon Manning</Profile>
+<Profile
+    username='JoseEspinosa'
+    affiliation='Centre for Genomic Regulation'
+>Jose Espinosa-Carrasco</Profile>
+<Profile
+    username='louperelo'
+    affiliation='Quantitative Biology Center, QBiC, University of Tübingen'
+>Louisa Perelo</Profile>
+<Profile
+    username='matthdsm'
+    affiliation='Center For Medical Genetics Ghent'
+>Matthias De Smet</Profile>
+<Profile
+    username='mashehu'
+    affiliation='Science for Life Laboratory'
+>Matthias Hörtenhuber</Profile>
+<Profile
+    username='maxulysse'
+    affiliation='Seqera Labs'
+>Maxime U. Garcia</Profile>
+<Profile
+    username='Midnighter'
+    affiliation='Unseen Bio ApS'
+>Moritz E. Beber</Profile>
+<Profile
+    username='nvnieuwk'
+    affiliation='Center For Medical Genetics Ghent'
+>Nicolas Vannieuwkerke</Profile>
+<Profile
+    username='ramprasadn'
+    affiliation='Science for Life Laboratory'
+>Ramprasad Neethiraj</Profile>
+<Profile
+    username='robsyme'
+    affiliation='Seqera Labs'
+>Rob Syme</Profile>
+<Profile
+    username='sppearce'
+    affiliation='Cancer Research UK Manchester Institute'
+>Simon Pearce</Profile>
+<Profile
+    username='sofstam'
+    affiliation='Karolinska Institute & Karolinska University Hospital'
+>Sofia Stamouli</Profile>
 
 We thank all the institutions and companies of the maintainers team for their support of nf-core.
 

--- a/src/content/about/governance.mdx
+++ b/src/content/about/governance.mdx
@@ -1,6 +1,7 @@
 ---
 title: Governance
 description: Governance of the nf-core community
+maxHeadingDepth: 2
 ---
 
 import Profile from '@components/GitHubProfilePictureExtended.svelte'

--- a/src/content/about/governance.mdx
+++ b/src/content/about/governance.mdx
@@ -5,7 +5,7 @@ description: Governance of the nf-core community
 
 import Profile from '@components/GitHubProfilePictureExtended.svelte'
 
-## Governance
+# Governance
 
 nf-core is committed to being an open, inclusive, productive, and open-source community.
 Anyone interested in the project can join the community and contribute to the project.
@@ -25,7 +25,7 @@ flowchart BT
 
 This page describes the structure of the nf-core community, including how governance teams are elected, their responsibilities, and how decisions are made.
 
-#### Steering committee
+## Steering committee
 
 Changes impacting the community require decisions informed by extensive experience with the nf-core project and the larger ecosystem.
 The steering committee is responsible for overseeing the running of the nf-core project.
@@ -34,12 +34,12 @@ The steering committee is made up of representatives from the core team and outs
 The steering committee is not a fixed size with its members being elected by the current steering committee.
 The steering committee will meet regularly to discuss the project, funding and personnel.
 
-##### Responsibilities
+### Responsibilities
 
 -   Guiding project initiatives
 -   Making decisions about the project, funds, and personnel
 
-##### Members
+### Members
 
 <Profile username='apeltzer'>Alexander Peltzer</Profile>
 <a class="btn btn-light rounded-pill mb-2 p-2">Ellen Sherwood</a>
@@ -49,7 +49,7 @@ The steering committee will meet regularly to discuss the project, funding and p
 <Profile username='ewels'>Phil Ewels</Profile>
 <Profile username='naepfel'>Sven Nahnsen</Profile>
 
-#### Core team
+## Core team
 
 The core team ensures the day-to-day running of the nf-core project and oversees the activities of governance teams.
 
@@ -59,7 +59,7 @@ The core team will aim to have representation from different genders, geography,
 Significant community decisions will be made by vote with any decision without a clear majority being passed to the steering committee to resolve.
 Core team members will appear as organization members on the GitHub organization and have administrator access to repositories.
 
-##### Responsibilities
+### Responsibilities
 
 -   Day-to-day community decisions
 -   Attendance at the core team annual meeting
@@ -67,7 +67,7 @@ Core team members will appear as organization members on the GitHub organization
 -   Sub-roles within the nf-core governance teams
 -   A strong community presence
 
-##### Members
+### Members
 
 <Profile username='christopher-hakkaart'>Chris Hakkaart</Profile>
 <Profile username='drpatelh'>Harshil Patel</Profile>
@@ -82,7 +82,7 @@ Core team members will appear as organization members on the GitHub organization
 <Profile username='mirpedrol'>Júlia Mir Pedrol</Profile>
 <Profile username='mribeirodantas'>Marcel Ribeiro-Dantas</Profile>
 
-##### Core team alumni
+### Core team alumni
 
 <Profile username='apeltzer'>Alexander Peltzer</Profile>
 <Profile username='alneberg'>Johannes Alneberg</Profile>
@@ -91,7 +91,7 @@ Core team members will appear as organization members on the GitHub organization
 <Profile username='renbot-bio'>Renuka Kudva</Profile>
 <Profile username='sven1103'>Sven F.</Profile>
 
-#### Safety
+## Safety
 
 The nf-core community should feel comfortable contributing to the project without the risk of harassment or abuse.
 The safety team is responsible for ensuring the community is a safe place and responding to instances of misconduct.
@@ -100,20 +100,20 @@ The safety team is made up of community members who have displayed integrity, st
 The safety team is elected by the core team, is not a fixed size, and will scale as the community grows.
 The safety team is not a part of the core team and can report directly to the steering committee.
 
-##### Members
+### Members
 
 <Profile username='ctuni'>Cris Tuñí</Profile>
 <Profile username='heuermh'>Michael Heuer</Profile>
 <Profile username='snafees'>Saba Nafees</Profile>
 
-##### Responsibilities
+### Responsibilities
 
 -   Write and maintain the nf-core code of conduct
 -   Be available for nf-core events (online or in person)
 -   Monitor Slack channels for instances of misconduct
 -   Promptly respond to reports of misconduct and escalate to the core team or steering committee as necessary
 
-#### Infrastructure
+## Infrastructure
 
 Tooling is a fundamental part of the nf-core community.
 The infrastructure team is responsible for the development and implementation of the nf-core tooling framework.
@@ -122,21 +122,21 @@ The infrastructure team will have one or more leads who are responsible for over
 The infrastructure team is elected by the core team, is not a fixed size, and will scale as the community grows.
 The infrastructure team will have administrator access to repositories.
 
-##### Responsibilities
+### Responsibilities
 
 -   Development and maintenance of nf-core tools, website, and mega tests
 -   Regular attendance at maintenance team meetings
 
-##### Leads
+### Leads
 
 <Profile username='ewels'>Phil Ewels</Profile>
 
-##### Members
+### Members
 
 <Profile username='mirpedrol'>Júlia Mir Pedrol</Profile>
 <Profile username='mashehu'>Matthias Hörtenhuber</Profile>
 
-#### Outreach
+## Outreach
 
 Outreach is an important part of any community project.
 The outreach team is responsible for overseeing the organization and running community outreach efforts, including, but not limited to, the nf-core ambassador program, hackathons, and the `#bytesize` seminar series.
@@ -146,20 +146,20 @@ New members will be invited to be a part of the outreach team based on experienc
 The outreach team is not a fixed size and will scale as the community grows.
 The outreach leads will have access to community social media and YouTube accounts (e.g., Twitter and YouTube).
 
-##### Responsibilities
+### Responsibilities
 
 -   Organizing and running the `#bytesize` seminar series
 -   Leading the organization of hackathons, training sessions, mentorship program, ambassador program, and other outreach events
 -   Creating and sharing community content
 -   Regular attendance at outreach team meetings
 
-##### Leads
+### Leads
 
 <Profile username='christopher-hakkaart'>Chris Hakkaart</Profile>
 <Profile username='FranBonath'>Franziska Bonath</Profile>
 <Profile username='mribeirodantas'>Marcel Ribeiro-Dantas</Profile>
 
-##### Members
+### Members
 
 <Profile username='abhi18av'>Abhinav Sharma</Profile>
 <Profile username='Emiller88'>Edmund Miller</Profile>
@@ -167,11 +167,11 @@ The outreach leads will have access to community social media and YouTube accoun
 <Profile username='pcantalupo'>Paul Cantalupo</Profile>
 <Profile username='yuukiiwa'>Yuk Kei</Profile>
 
-##### Alumni
+### Alumni
 
 <Profile username='Xesus-Abalo'>Xesús M. Abalo</Profile>
 
-#### Maintainers
+## Maintainers
 
 nf-core test data, modules, and pipeline repositories require regular upkeep and maintenance.
 The maintainer's team takes an active role in managing nf-core repositories in collaboration with the wider nf-core community.
@@ -181,7 +181,7 @@ New members are invited to be a part maintainers team by current maintainers bas
 The maintainer's team is not a fixed size and will scale as the community grows.
 nf-core maintainers will have write access to repositories.
 
-##### Responsibilities
+### Responsibilities
 
 -   Respond to `#github-invitations`
 -   Review module, subworkflow, and pipeline release pull requests
@@ -189,7 +189,7 @@ nf-core maintainers will have write access to repositories.
 -   Manage test data
 -   Enable and promote nf-core community values
 
-##### Members
+### Members
 
 <Profile
     username='adamrtalbot'
@@ -290,7 +290,7 @@ nf-core maintainers will have write access to repositories.
 
 We thank all the institutions and companies of the maintainers team for their support of nf-core.
 
-#### Ambassadors
+## Ambassadors
 
 nf-core recognizes a vibrant, worldwide group of nf-core experts whose enthusiasm for knowledge-sharing drives the community forward.
 Ambassadors go above and beyond to share knowledge in a variety of ways including online via social media, blog posts and articles; or in person at conferences, workshops, and user group events.
@@ -300,7 +300,7 @@ Ambassadors are expected to regularly engage with the wider community and will b
 
 More information about becoming a Nextflow and nf-core ambassador will be available soon!
 
-##### Responsibilities
+### Responsibilities
 
 -   Engaging with local, national, and international Nextflow and nf-core community
 -   Writing or sharing tweets, blogs, articles, and technical documentation

--- a/src/content/about/governance.mdx
+++ b/src/content/about/governance.mdx
@@ -155,21 +155,27 @@ The outreach leads will have access to community social media and YouTube accoun
 
 **Leads**
 
+<div class="d-flex flex-wrap">
 <Profile username='christopher-hakkaart'>Chris Hakkaart</Profile>
 <Profile username='FranBonath'>Franziska Bonath</Profile>
 <Profile username='mribeirodantas'>Marcel Ribeiro-Dantas</Profile>
+</div>
 
 **Members**
 
+<div class="d-flex flex-wrap">
 <Profile username='abhi18av'>Abhinav Sharma</Profile>
 <Profile username='Emiller88'>Edmund Miller</Profile>
 <Profile username='MaxUlysse'>Maxime Garcia</Profile>
 <Profile username='pcantalupo'>Paul Cantalupo</Profile>
 <Profile username='yuukiiwa'>Yuk Kei</Profile>
+</div>
 
 **Alumni**
 
+<div class="d-flex flex-wrap">
 <Profile username='Xesus-Abalo'>Xesús M. Abalo</Profile>
+</div>
 
 #### Maintainers
 
@@ -190,7 +196,7 @@ nf-core maintainers will have write access to repositories.
 -   Enable and promote nf-core community values
 
 **Members**
-
+<div class="d-flex flex-wrap">
 <Profile
     username='adamrtalbot'
     affiliation='Nonacus'
@@ -287,7 +293,7 @@ nf-core maintainers will have write access to repositories.
     username='sofstam'
     affiliation='Karolinska Institute & Karolinska University Hospital'
 >Sofia Stamouli</Profile>
-
+</div>
 We thank all the institutions and companies of the maintainers team for their support of nf-core.
 
 #### Ambassadors

--- a/src/content/about/governance.mdx
+++ b/src/content/about/governance.mdx
@@ -35,12 +35,12 @@ The steering committee is made up of representatives from the core team and outs
 The steering committee is not a fixed size with its members being elected by the current steering committee.
 The steering committee will meet regularly to discuss the project, funding and personnel.
 
-### Responsibilities
+##### Responsibilities
 
 -   Guiding project initiatives
 -   Making decisions about the project, funds, and personnel
 
-### Members
+##### Members
 
 <Profile username='apeltzer'>Alexander Peltzer</Profile>
 <a class="btn btn-light rounded-pill mb-2 p-2">Ellen Sherwood</a>
@@ -60,7 +60,7 @@ The core team will aim to have representation from different genders, geography,
 Significant community decisions will be made by vote with any decision without a clear majority being passed to the steering committee to resolve.
 Core team members will appear as organization members on the GitHub organization and have administrator access to repositories.
 
-### Responsibilities
+##### Responsibilities
 
 -   Day-to-day community decisions
 -   Attendance at the core team annual meeting
@@ -68,7 +68,7 @@ Core team members will appear as organization members on the GitHub organization
 -   Sub-roles within the nf-core governance teams
 -   A strong community presence
 
-### Members
+##### Members
 
 <Profile username='christopher-hakkaart'>Chris Hakkaart</Profile>
 <Profile username='drpatelh'>Harshil Patel</Profile>
@@ -83,7 +83,7 @@ Core team members will appear as organization members on the GitHub organization
 <Profile username='mirpedrol'>Júlia Mir Pedrol</Profile>
 <Profile username='mribeirodantas'>Marcel Ribeiro-Dantas</Profile>
 
-### Core team alumni
+##### Alumni
 
 <Profile username='apeltzer'>Alexander Peltzer</Profile>
 <Profile username='alneberg'>Johannes Alneberg</Profile>
@@ -101,18 +101,18 @@ The safety team is made up of community members who have displayed integrity, st
 The safety team is elected by the core team, is not a fixed size, and will scale as the community grows.
 The safety team is not a part of the core team and can report directly to the steering committee.
 
-### Members
-
-<Profile username='ctuni'>Cris Tuñí</Profile>
-<Profile username='heuermh'>Michael Heuer</Profile>
-<Profile username='snafees'>Saba Nafees</Profile>
-
-### Responsibilities
+##### Responsibilities
 
 -   Write and maintain the nf-core code of conduct
 -   Be available for nf-core events (online or in person)
 -   Monitor Slack channels for instances of misconduct
 -   Promptly respond to reports of misconduct and escalate to the core team or steering committee as necessary
+
+##### Members
+
+<Profile username='ctuni'>Cris Tuñí</Profile>
+<Profile username='heuermh'>Michael Heuer</Profile>
+<Profile username='snafees'>Saba Nafees</Profile>
 
 ## Infrastructure
 
@@ -123,16 +123,16 @@ The infrastructure team will have one or more leads who are responsible for over
 The infrastructure team is elected by the core team, is not a fixed size, and will scale as the community grows.
 The infrastructure team will have administrator access to repositories.
 
-### Responsibilities
+##### Responsibilities
 
 -   Development and maintenance of nf-core tools, website, and mega tests
 -   Regular attendance at maintenance team meetings
 
-### Leads
+##### Leads
 
 <Profile username='ewels'>Phil Ewels</Profile>
 
-### Members
+##### Members
 
 <Profile username='mirpedrol'>Júlia Mir Pedrol</Profile>
 <Profile username='mashehu'>Matthias Hörtenhuber</Profile>
@@ -147,20 +147,20 @@ New members will be invited to be a part of the outreach team based on experienc
 The outreach team is not a fixed size and will scale as the community grows.
 The outreach leads will have access to community social media and YouTube accounts (e.g., Twitter and YouTube).
 
-### Responsibilities
+##### Responsibilities
 
 -   Organizing and running the `#bytesize` seminar series
 -   Leading the organization of hackathons, training sessions, mentorship program, ambassador program, and other outreach events
 -   Creating and sharing community content
 -   Regular attendance at outreach team meetings
 
-### Leads
+##### Leads
 
 <Profile username='christopher-hakkaart'>Chris Hakkaart</Profile>
 <Profile username='FranBonath'>Franziska Bonath</Profile>
 <Profile username='mribeirodantas'>Marcel Ribeiro-Dantas</Profile>
 
-### Members
+##### Members
 
 <Profile username='abhi18av'>Abhinav Sharma</Profile>
 <Profile username='Emiller88'>Edmund Miller</Profile>
@@ -168,7 +168,7 @@ The outreach leads will have access to community social media and YouTube accoun
 <Profile username='pcantalupo'>Paul Cantalupo</Profile>
 <Profile username='yuukiiwa'>Yuk Kei</Profile>
 
-### Alumni
+##### Alumni
 
 <Profile username='Xesus-Abalo'>Xesús M. Abalo</Profile>
 
@@ -182,7 +182,7 @@ New members are invited to be a part maintainers team by current maintainers bas
 The maintainer's team is not a fixed size and will scale as the community grows.
 nf-core maintainers will have write access to repositories.
 
-### Responsibilities
+##### Responsibilities
 
 -   Respond to `#github-invitations`
 -   Review module, subworkflow, and pipeline release pull requests
@@ -190,7 +190,7 @@ nf-core maintainers will have write access to repositories.
 -   Manage test data
 -   Enable and promote nf-core community values
 
-### Members
+##### Members
 
 <Profile
     username='adamrtalbot'
@@ -301,7 +301,7 @@ Ambassadors are expected to regularly engage with the wider community and will b
 
 More information about becoming a Nextflow and nf-core ambassador will be available soon!
 
-### Responsibilities
+##### Responsibilities
 
 -   Engaging with local, national, and international Nextflow and nf-core community
 -   Writing or sharing tweets, blogs, articles, and technical documentation

--- a/src/content/about/governance.mdx
+++ b/src/content/about/governance.mdx
@@ -34,12 +34,12 @@ The steering committee is made up of representatives from the core team and outs
 The steering committee is not a fixed size with its members being elected by the current steering committee.
 The steering committee will meet regularly to discuss the project, funding and personnel.
 
-**Responsibilities**
+##### Responsibilities
 
 -   Guiding project initiatives
 -   Making decisions about the project, funds, and personnel
 
-**Members**
+##### Members
 
 <Profile username='apeltzer'>Alexander Peltzer</Profile>
 <a class="btn btn-light rounded-pill mb-2 p-2">Ellen Sherwood</a>
@@ -59,7 +59,7 @@ The core team will aim to have representation from different genders, geography,
 Significant community decisions will be made by vote with any decision without a clear majority being passed to the steering committee to resolve.
 Core team members will appear as organization members on the GitHub organization and have administrator access to repositories.
 
-**Responsibilities**
+##### Responsibilities
 
 -   Day-to-day community decisions
 -   Attendance at the core team annual meeting
@@ -67,7 +67,7 @@ Core team members will appear as organization members on the GitHub organization
 -   Sub-roles within the nf-core governance teams
 -   A strong community presence
 
-**Members**
+##### Members
 
 <Profile username='christopher-hakkaart'>Chris Hakkaart</Profile>
 <Profile username='drpatelh'>Harshil Patel</Profile>
@@ -82,7 +82,7 @@ Core team members will appear as organization members on the GitHub organization
 <Profile username='mirpedrol'>Júlia Mir Pedrol</Profile>
 <Profile username='mribeirodantas'>Marcel Ribeiro-Dantas</Profile>
 
-**Core team alumni**
+##### Core team alumni
 
 <Profile username='apeltzer'>Alexander Peltzer</Profile>
 <Profile username='alneberg'>Johannes Alneberg</Profile>
@@ -100,13 +100,13 @@ The safety team is made up of community members who have displayed integrity, st
 The safety team is elected by the core team, is not a fixed size, and will scale as the community grows.
 The safety team is not a part of the core team and can report directly to the steering committee.
 
-**Members**
+##### Members
 
 <Profile username='ctuni'>Cris Tuñí</Profile>
 <Profile username='heuermh'>Michael Heuer</Profile>
 <Profile username='snafees'>Saba Nafees</Profile>
 
-**Responsibilities**
+##### Responsibilities
 
 -   Write and maintain the nf-core code of conduct
 -   Be available for nf-core events (online or in person)
@@ -122,16 +122,16 @@ The infrastructure team will have one or more leads who are responsible for over
 The infrastructure team is elected by the core team, is not a fixed size, and will scale as the community grows.
 The infrastructure team will have administrator access to repositories.
 
-**Responsibilities**
+##### Responsibilities
 
 -   Development and maintenance of nf-core tools, website, and mega tests
 -   Regular attendance at maintenance team meetings
 
-**Leads**
+##### Leads
 
 <Profile username='ewels'>Phil Ewels</Profile>
 
-**Members**
+##### Members
 
 <Profile username='mirpedrol'>Júlia Mir Pedrol</Profile>
 <Profile username='mashehu'>Matthias Hörtenhuber</Profile>
@@ -146,36 +146,30 @@ New members will be invited to be a part of the outreach team based on experienc
 The outreach team is not a fixed size and will scale as the community grows.
 The outreach leads will have access to community social media and YouTube accounts (e.g., Twitter and YouTube).
 
-**Responsibilities**
+##### Responsibilities
 
 -   Organizing and running the `#bytesize` seminar series
 -   Leading the organization of hackathons, training sessions, mentorship program, ambassador program, and other outreach events
 -   Creating and sharing community content
 -   Regular attendance at outreach team meetings
 
-**Leads**
+##### Leads
 
-<div class="d-flex flex-wrap">
 <Profile username='christopher-hakkaart'>Chris Hakkaart</Profile>
 <Profile username='FranBonath'>Franziska Bonath</Profile>
 <Profile username='mribeirodantas'>Marcel Ribeiro-Dantas</Profile>
-</div>
 
-**Members**
+##### Members
 
-<div class="d-flex flex-wrap">
 <Profile username='abhi18av'>Abhinav Sharma</Profile>
 <Profile username='Emiller88'>Edmund Miller</Profile>
 <Profile username='MaxUlysse'>Maxime Garcia</Profile>
 <Profile username='pcantalupo'>Paul Cantalupo</Profile>
 <Profile username='yuukiiwa'>Yuk Kei</Profile>
-</div>
 
-**Alumni**
+##### Alumni
 
-<div class="d-flex flex-wrap">
 <Profile username='Xesus-Abalo'>Xesús M. Abalo</Profile>
-</div>
 
 #### Maintainers
 
@@ -187,7 +181,7 @@ New members are invited to be a part maintainers team by current maintainers bas
 The maintainer's team is not a fixed size and will scale as the community grows.
 nf-core maintainers will have write access to repositories.
 
-**Responsibilities**
+##### Responsibilities
 
 -   Respond to `#github-invitations`
 -   Review module, subworkflow, and pipeline release pull requests
@@ -195,8 +189,8 @@ nf-core maintainers will have write access to repositories.
 -   Manage test data
 -   Enable and promote nf-core community values
 
-**Members**
-<div class="d-flex flex-wrap">
+##### Members
+
 <Profile
     username='adamrtalbot'
     affiliation='Nonacus'
@@ -293,7 +287,7 @@ nf-core maintainers will have write access to repositories.
     username='sofstam'
     affiliation='Karolinska Institute & Karolinska University Hospital'
 >Sofia Stamouli</Profile>
-</div>
+
 We thank all the institutions and companies of the maintainers team for their support of nf-core.
 
 #### Ambassadors
@@ -306,7 +300,7 @@ Ambassadors are expected to regularly engage with the wider community and will b
 
 More information about becoming a Nextflow and nf-core ambassador will be available soon!
 
-**Responsibilities**
+##### Responsibilities
 
 -   Engaging with local, national, and international Nextflow and nf-core community
 -   Writing or sharing tweets, blogs, articles, and technical documentation

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -34,6 +34,7 @@ const about = defineCollection({
         title: z.string(),
         description: z.string(),
         md_github_url: z.string().url().optional(),
+        maxHeadingDepth: z.number().optional(),
     }),
 });
 

--- a/src/layouts/MarkdownTocLayout.astro
+++ b/src/layouts/MarkdownTocLayout.astro
@@ -18,6 +18,7 @@ export interface Props {
         name: string;
         content: string;
     }[];
+    maxHeadingDepth?: number;
 }
 
 const {
@@ -30,6 +31,7 @@ const {
     sections = [],
     meta_title = '',
     docSearchTags = [],
+    maxHeadingDepth = 4,
 } = Astro.props;
 ---
 
@@ -83,7 +85,7 @@ const {
             </div>
         </div>
         <div class="col-12 col-md-2 toc">
-            <SidebarToc headings={headings} client:idle />
+            <SidebarToc headings={headings} maxHeadingDepth={maxHeadingDepth} client:idle />
         </div>
     </div>
     <slot name="pre-footer" slot="pre-footer" />

--- a/src/pages/[about].astro
+++ b/src/pages/[about].astro
@@ -20,6 +20,7 @@ const { headings, Content } = await Astro.props.about.render();
 if (!md_github_url) {
     md_github_url = 'https://github.com/nf-core/website/blob/main/src/content/about/' + Astro.props.about.id;
 }
+const maxHeadingDepth = Astro.props.about.data.maxHeadingDepth || 4;
 ---
 
 <MarkdownTocLayout
@@ -28,6 +29,7 @@ if (!md_github_url) {
     md_github_url={md_github_url}
     headings={headings}
     left_sidebar={false}
+    maxHeadingDepth={maxHeadingDepth}
 >
     <Content />
 </MarkdownTocLayout>

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -369,6 +369,14 @@ h4:focus .header-link,
   }
 }
 
+.markdown-content h5 {
+  color: var(--bs-body-color);
+  font-family: $font-family-sans-serif;
+  margin-top: 1rem;
+  font-weight: $font-weight-semibold;
+  font-size: $font-size-base * 1.1;
+}
+
 .markdown-content,
 .events,
 .card {


### PR DESCRIPTION
Governance page username badge improvements:

* Made a new sub-component and massively reduced markup in the MDX
* Move maintainers' affiliation info into the component
* Removed maintainers list

Maintainers list is now much, much easier to read:

![CleanShot 2023-08-22 at 00 26 41@2x](https://github.com/nf-core/website/assets/465550/919a46e6-df96-4e22-9337-998b585ad263)

Bed time now, but remaining - can't get the text to align properly:

![CleanShot 2023-08-22 at 00 25 52@2x](https://github.com/nf-core/website/assets/465550/c7a43219-f94e-4f5e-a1cf-eaa0ce9ec6c7)

Should be a nice tight-wrapping circle, like this:

![CleanShot 2023-08-22 at 00 26 03@2x](https://github.com/nf-core/website/assets/465550/0cc2a781-bb4a-4d07-a4d7-39f002cc9dc1)

Help to fix this appreciated 🙏🏻 