### PR TITLE
Adding SUN SATTBI group

### DIFF
--- a/src/config/contributors.yaml
+++ b/src/config/contributors.yaml
@@ -980,3 +980,18 @@ contributors:
     contact_github: Sydney-Informatics-Hub
     location: [-33.88839664786049, 151.1873279393093]
     twitter: Sydney_CRF
+
+
+  - full_name: Stellenbosch University, Bioinformatics research unit
+    short_name: SUN
+    description: >
+      As tuberculosis research in South Africa has become increasingly reliant on molecular biotechnologies, the volume of data produced has grown considerably. The South African Tuberculosis Bioinformatics Initiative (SATBBI) was created in response to this growth, creating a group of bioinformatics researchers engaged with the tuberculosis research community in South Africa.
+    address: Francie Van Zijl Dr, Tygerberg, Cape Town, 7505, South Africa
+    url: http://www.sun.ac.za/english/faculty/healthsciences/Molecular_Biology_Human_Genetics/bioinformatics
+    affiliation: Stellenbosch University
+    image_fn: SUN.svg
+    contact: Abhinav Sharma
+    contact_email: abhinavsharma@sun.ac.za
+    contact_github: https://github.com/SATBBI
+    location: [-33.907562,18.614187]
+    twitter: SuMBHG


### PR DESCRIPTION
This PR adds the location for Stellenbosch medical campus, where the bioinformatics group is located.