### PR TITLE
put prettier command inside bash code block

### DIFF
--- a/src/content/docs/contributing/modules.md
+++ b/src/content/docs/contributing/modules.md
@@ -174,7 +174,7 @@ We have implemented a number of commands in the `nf-core/tools` package to make 
 
 9. Check that the new module you've added follows the [new module guidelines](#new-module-guidelines-and-pr-review-checklist)
 
-10. Run [`prettier`](https://nf-co.re/docs/contributing/code_formating) on all edited and generated files
+10. Run [`prettier`](https://nf-co.re/docs/contributing/code_formating) on all edited and generated files:
 
     ```bash
     prettier -w .

--- a/src/content/docs/contributing/modules.md
+++ b/src/content/docs/contributing/modules.md
@@ -175,7 +175,11 @@ We have implemented a number of commands in the `nf-core/tools` package to make 
 9. Check that the new module you've added follows the [new module guidelines](#new-module-guidelines-and-pr-review-checklist)
 
 10. Run [`prettier`](https://nf-co.re/docs/contributing/code_formating) on all edited and generated files
+
+    ```bash
     prettier -w .
+    ```
+
 11. Lint the module locally to check that it adheres to nf-core guidelines before submission
 
     ```console


### PR DESCRIPTION
The command was trailing the sentence in the docs, so I added a code block around it.