### PR TITLE
Add hint about debug profile

### DIFF
--- a/src/content/docs/contributing/adding_pipelines.md
+++ b/src/content/docs/contributing/adding_pipelines.md
@@ -131,6 +131,9 @@ to make sure that your workflow passes all of the nf-core compatibility tests.
 The automated tests on Github Actions also run this, so you should get a
 notification from GitHub if something breaks.
 
+When testing the pipeline you can add the `debug` profile (`-profile debug`) to the Nextflow command line,
+to enable warnings about process selectors, show additional debug output and disable cleanup.
+
 ## Running with test data
 
 Whilst the linting tests are good, they're not sufficient by themselves.

--- a/src/content/docs/contributing/contributing_to_pipelines.md
+++ b/src/content/docs/contributing/contributing_to_pipelines.md
@@ -48,6 +48,9 @@ If you're new to working with git, you can view the [GitHub pull requests docume
 
 ## Testing
 
+You can optionally test your changes by running the pipeline locally. Then it is recommended to use the `debug` profile to
+receive warnings about process selectors and other debug info. Example: `nextflow run . -profile debug,test,docker --outdir <OUTDIR>`.
+
 When you create a pull request with changes, [GitHub Actions](https://github.com/features/actions) will run automatic tests.
 Typically, pull-requests are only fully reviewed when these tests are passing, though of course, we can help out before then.
 
@@ -66,6 +69,7 @@ Each `nf-core` pipeline should be set up with a minimal set of test data.
 `GitHub Actions` then runs the pipeline on this data to ensure that it exits successfully.
 If there are any failures then the automated tests fail.
 These tests are run both with the latest available version of `Nextflow` and also the minimum required version that is stated in the pipeline code.
+
 
 ## Patching bugs
 


### PR DESCRIPTION
The changes in PR  #2472 make it so process selector warnings are hidden by default, to address issue https://github.com/nf-core/tools/issues/2161. This PR contains changes to the documentation for adding new pipelines and for contributing to pipelines, to alert developers that the `debug` profile is required in order to see the process selector warnings.