### PR TITLE
Update pytest_software.yml to pytest_modules.yml

### DIFF
--- a/src/content/docs/contributing/tutorials/dsl2_modules_tutorial.md
+++ b/src/content/docs/contributing/tutorials/dsl2_modules_tutorial.md
@@ -472,7 +472,7 @@ workflow test_fgbio_fastqtobam {
 In order to carry out the test, _pytest-workflow_ will search for information stored in 2 files.
 
 ```bash
-modules/tests/config/pytest_software.yml
+modules/tests/config/pytest_modules.yml
 modules/tests/software/fgbio/demofastqtobam/test.yml
 ```
 
@@ -498,7 +498,7 @@ This process will run the test workflow, generate the outputs and update the `te
 This should be already updated for you when building the template - you shouldn't have to touch these sections!
 :::
 
-Before running some local tests, we should make sure the `pytest_software.yml` looks like we expect, i.e. contains the following lines
+Before running some local tests, we should make sure the `pytest_modules.yml` looks like we expect, i.e. contains the following lines
 
 ```yaml
 fgbio_demofastqtobam:


### PR DESCRIPTION
As reported [here](https://nfcore.slack.com/archives/CJRH30T6V/p1697464768424299) `pytest_software.yml` has been renamed as `pytest_modules.yml`. Modules docs updated accordingly.