### PR TITLE
chore: Add nf-core docs teams to docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+src/content @nf-core/docs


### PR DESCRIPTION
Maybe add @FranBonath to `content/events/`, and maybe @nf-core/outreach or core to `content/about`?