### PR TITLE
Add using closure in modules.conf to process directives that use params.*

### DIFF
--- a/src/content/docs/contributing/modules.md
+++ b/src/content/docs/contributing/modules.md
@@ -657,15 +657,15 @@ The key words "MUST", "MUST NOT", "SHOULD", etc. are to be interpreted as descri
       <summary>Rationale</summary>
       A disadvantage of passing arguments via ext.args is that it splits up how information is passed to a module, which can be difficult to understand where module inputs are defined.
 
-      The justification behind using the `ext.args` is to provide more flexibility to users. As `ext.args` is derived from the configuration (e.g. `modules.config`), advanced users can overwrite the default `ext.args` and supply their own arguments to modify the behaviour of a module. This can increase the capabilities of a pipeline beyond what the original developers intended.
+    The justification behind using the `ext.args` is to provide more flexibility to users. As `ext.args` is derived from the configuration (e.g. `modules.config`), advanced users can overwrite the default `ext.args` and supply their own arguments to modify the behaviour of a module. This can increase the capabilities of a pipeline beyond what the original developers intended.
 
-      Initially these were passed via the main workflow script using custom functions (e.g. `addParams`) and other additional nf-core custom methods, but this had a syntax overhead and other limitations that were found to be more difficult to use and understand by pipeline developers. Therefore using the 'native' `ext` functionality provided by Nextflow was easier to understand, maintain and use.
+    Initially these were passed via the main workflow script using custom functions (e.g. `addParams`) and other additional nf-core custom methods, but this had a syntax overhead and other limitations that were found to be more difficult to use and understand by pipeline developers. Therefore using the 'native' `ext` functionality provided by Nextflow was easier to understand, maintain and use.
 
-      Note that sample-specific parameters can still be provided to an instance of a process by storing these in `meta`, and providing these to the `ext.args` definition in `modules.config`. A closure is used to make Nextflow evaluate the code in the code in the string.
+    Note that sample-specific parameters can still be provided to an instance of a process by storing these in `meta`, and providing these to the `ext.args` definition in `modules.config`. A closure is used to make Nextflow evaluate the code in the code in the string.
 
-      ```nextflow
-      ext.args = { "--id ${meta.id}" }
-      ```
+    ```nextflow
+    ext.args = { "--id ${meta.id}" }
+    ```
 
       </details>
 
@@ -702,27 +702,27 @@ The key words "MUST", "MUST NOT", "SHOULD", etc. are to be interpreted as descri
       <summary>Rationale</summary>
       Modules should be written to allow as much flexibility to pipeline developers as possible.
 
-      Hardcoding `meta` fields in a module will reduce the freedom of developers to use their own names for metadata, which would make more sense in that particular context.
+    Hardcoding `meta` fields in a module will reduce the freedom of developers to use their own names for metadata, which would make more sense in that particular context.
 
-      As all non-mandatory arguments must go via `$args`, pipeline developers can insert such `meta` information into `$args` with whatever name they wish.
+    As all non-mandatory arguments must go via `$args`, pipeline developers can insert such `meta` information into `$args` with whatever name they wish.
 
-      So, in the module code we DO NOT do:
+    So, in the module code we DO NOT do:
 
-      ```bash
-      my_command -r ${meta.strand} input.txt output.txt
-      ```
+    ```bash
+    my_command -r ${meta.strand} input.txt output.txt
+    ```
 
-      ... but rather, in `modules.conf`
+    ... but rather, in `modules.conf`
 
-      ```nextflow
-      ext.args = { "--r ${meta.<pipeline_authors_choice_of_name>}" }
-      ```
+    ```nextflow
+    ext.args = { "--r ${meta.<pipeline_authors_choice_of_name>}" }
+    ```
 
-      ... and then in the module code `main.nf`:
+    ... and then in the module code `main.nf`:
 
-      ```bash
-      my_command $args input.txt output.txt
-      ```
+    ```bash
+    my_command $args input.txt output.txt
+    ```
 
       </details>
 

--- a/src/content/docs/contributing/modules.md
+++ b/src/content/docs/contributing/modules.md
@@ -629,7 +629,7 @@ The key words "MUST", "MUST NOT", "SHOULD", etc. are to be interpreted as descri
 
 3.  All _non-mandatory_ command-line tool _non-file_ arguments MUST be provided as a string via the `$task.ext.args` variable.
 
-    - The value of `task.ext.args` is supplied from the `modules.config` file by assigning a string value to `ext.args`.
+    - The value of `task.ext.args` is supplied from the `modules.config` file by assigning a closure that returns a string value to `ext.args`. The closure is necessary to update parameters supplied in a config with `-c`.
 
       ```groovy title="<module>.nf"
       script:
@@ -644,10 +644,10 @@ The key words "MUST", "MUST NOT", "SHOULD", etc. are to be interpreted as descri
 
       ```groovy title="modules.config"
           withName: <module> {
-              ext.args = [                                                          // Assign either a string, or closure which returns a string
+              ext.args = { [                                                        // Assign a closure which returns a string
                   '--quiet',
                   params.fastqc_kmer_size ? "-k ${params.fastqc_kmer_size}" : ''    // Parameter dependent values can be provided like so
-              ].join(' ')                                                           // Join converts the list here to a string.
+              ].join(' ') }                                                         // Join converts the list here to a string.
               ext.prefix = { "${meta.id}" }                                         // A closure can be used to access variables defined in the script
           }
       }
@@ -657,15 +657,15 @@ The key words "MUST", "MUST NOT", "SHOULD", etc. are to be interpreted as descri
       <summary>Rationale</summary>
       A disadvantage of passing arguments via ext.args is that it splits up how information is passed to a module, which can be difficult to understand where module inputs are defined.
 
-    The justification behind using the `ext.args` is to provide more flexibility to users. As `ext.args` is derived from the configuration (e.g. `modules.config`), advanced users can overwrite the default `ext.args` and supply their own arguments to modify the behaviour of a module. This can increase the capabilities of a pipeline beyond what the original developers intended.
+      The justification behind using the `ext.args` is to provide more flexibility to users. As `ext.args` is derived from the configuration (e.g. `modules.config`), advanced users can overwrite the default `ext.args` and supply their own arguments to modify the behaviour of a module. This can increase the capabilities of a pipeline beyond what the original developers intended.
 
-    Initially these were passed via the main workflow script using custom functions (e.g. `addParams`) and other additional nf-core custom methods, but this had a syntax overhead and other limitations that were found to be more difficult to use and understand by pipeline developers. Therefore using the 'native' `ext` functionality provided by Nextflow was easier to understand, maintain and use.
+      Initially these were passed via the main workflow script using custom functions (e.g. `addParams`) and other additional nf-core custom methods, but this had a syntax overhead and other limitations that were found to be more difficult to use and understand by pipeline developers. Therefore using the 'native' `ext` functionality provided by Nextflow was easier to understand, maintain and use.
 
-    Note that sample-specific parameters can still be provided to an instance of a process by storing these in `meta`, and providing these to the `ext.args` definition in `modules.config`. A closure is used to make Nextflow evaluate the code in the code in the string.
+      Note that sample-specific parameters can still be provided to an instance of a process by storing these in `meta`, and providing these to the `ext.args` definition in `modules.config`. A closure is used to make Nextflow evaluate the code in the code in the string.
 
-    ```nextflow
-    ext.args = { "--id ${meta.id}" }
-    ```
+      ```nextflow
+      ext.args = { "--id ${meta.id}" }
+      ```
 
       </details>
 
@@ -702,27 +702,27 @@ The key words "MUST", "MUST NOT", "SHOULD", etc. are to be interpreted as descri
       <summary>Rationale</summary>
       Modules should be written to allow as much flexibility to pipeline developers as possible.
 
-    Hardcoding `meta` fields in a module will reduce the freedom of developers to use their own names for metadata, which would make more sense in that particular context.
+      Hardcoding `meta` fields in a module will reduce the freedom of developers to use their own names for metadata, which would make more sense in that particular context.
 
-    As all non-mandatory arguments must go via `$args`, pipeline developers can insert such `meta` information into `$args` with whatever name they wish.
+      As all non-mandatory arguments must go via `$args`, pipeline developers can insert such `meta` information into `$args` with whatever name they wish.
 
-    So, in the module code we DO NOT do:
+      So, in the module code we DO NOT do:
 
-    ```bash
-    my_command -r ${meta.strand} input.txt output.txt
-    ```
+      ```bash
+      my_command -r ${meta.strand} input.txt output.txt
+      ```
 
-    ... but rather, in `modules.conf`
+      ... but rather, in `modules.conf`
 
-    ```nextflow
-    ext.args = { "--r ${meta.<pipeline_authors_choice_of_name>}" }
-    ```
+      ```nextflow
+      ext.args = { "--r ${meta.<pipeline_authors_choice_of_name>}" }
+      ```
 
-    ... and then in the module code `main.nf`:
+      ... and then in the module code `main.nf`:
 
-    ```bash
-    my_command $args input.txt output.txt
-    ```
+      ```bash
+      my_command $args input.txt output.txt
+      ```
 
       </details>
 

--- a/src/content/docs/contributing/tutorials/adding_modules_to_pipelines.md
+++ b/src/content/docs/contributing/tutorials/adding_modules_to_pipelines.md
@@ -21,6 +21,8 @@ Different pipelines may have different workflows, but the following steps will c
 5. Add any necessary parameters for the module with defaults to `nextflow.config`
 6. Insert any pipeline level parameters (`params.*`) into the `ext.args` of corresponding `conf/modules.config`
    - In some cases these may need to be passed directly to the module itself, e.g. `FASTP( reads, params.save_trimmed_fail, params.save_merged)`
+   - Ensure all directives which use `params.*` supply the value as a closure (i.e., enclosed within `{}`, e.g., `ext.args = { "--option $params.option" }`).
+     This ensures parameters supplied in a config `-c` are correctly resolved.
 7. Update the `nextflow_schema.json` to include new parameters with
 
    ```bash


### PR DESCRIPTION
Updates docs to include that process directives which include `params.*` should be supplied as closures.