### PR TITLE
chore: Add bytesize as owners of the bytesize files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 src/content/docs @nf-core/docs
+src/content/events/*/bytesize*.md @nf-core/bytesize


### PR DESCRIPTION
Should auto-request a review from the team when a new transcript comes in.   
  
Hopefully should get more eyes on them, and help keep up with the large amount of work.  
  
Came out of a conversation with @ewels where he was talking about how the search bar is finding the transcripts now and how powerful that was.