### PR TITLE
Fix NXF_OFFLINE

### DIFF
--- a/src/content/docs/usage/offline.md
+++ b/src/content/docs/usage/offline.md
@@ -29,7 +29,7 @@ We do this by installing it locally on a machine that _does_ have an internet co
 - In your Nextflow configuration file, specify each plugin that you downloaded, both name and version, including default plugins. This will prevent Nextflow from trying to download newer versions of plugins.
 - Add the following environment variable in your `~/.bashrc` file:
   ```bash title=".bashrc"
-  export NXF_OFFLINE='TRUE'
+  export NXF_OFFLINE='true'
   ```
 
 ## Pipeline code


### PR DESCRIPTION
To use Nextflow offline, this variable should be set to `true` (small letters), instead of `TRUE`, see nextflow repo for details: https://github.com/nextflow-io/nextflow/blob/832bff241f64cc3ce9b4cdc794a58d1664c0933c/modules/nextflow/src/main/groovy/nextflow/cli/CmdRun.groovy#L247