### PR TITLE
Use CSS grid for pipeline and component cards

### DIFF
--- a/src/components/ListingCard.svelte
+++ b/src/components/ListingCard.svelte
@@ -2,7 +2,7 @@
     export let recentRelease: boolean = false;
 </script>
 
-<div class="card m-2">
+<div class="card">
     <div class="card-header" class:border-success={recentRelease}>
         <h2 class="mb-0">
             <slot name="card-header" />
@@ -14,13 +14,8 @@
 </div>
 
 <style lang="scss">
-    @import '@styles/_variables.scss';
     .card {
-        width: 32rem;
-    }
-    @include media-breakpoint-down(md) {
-        .card {
-            width: 100%;
-        }
+        width: 100%;
+        height: 100%;
     }
 </style>

--- a/src/components/component/ComponentListing.svelte
+++ b/src/components/component/ComponentListing.svelte
@@ -89,10 +89,12 @@
     });
 </script>
 
-<div class={`listing d-flex flex-wrap w-100 justify-content-center ${components[0].type}`}>
+<div class={`listing grid px-2 py-4 ${components[0].type}`}>
     {#if $DisplayStyle === 'grid'}
         {#each paginatedItems as component (component.name)}
-            <ComponentCard {component} />
+            <div class="g-col-12 g-col-md-6 g-col-xl-4">
+                <ComponentCard {component} />
+            </div>
         {/each}
     {:else}
         <table class="table table-responsive mx-3">

--- a/src/components/pipeline/PipelinesListing.svelte
+++ b/src/components/pipeline/PipelinesListing.svelte
@@ -131,7 +131,7 @@
     });
 </script>
 
-<div class="listing d-flex flex-wrap w-100 justify-content-center">
+<div class="listing grid px-2 py-4">
     {#if $DisplayStyle === 'grid'}
         {#if filteredPipelines.length === 0 && $SearchQuery !== ''}
             <div class="alert alert-warning" role="alert">
@@ -139,7 +139,9 @@
             </div>
         {:else}
             {#each filteredPipelines as pipeline (pipeline.name)}
-                <PipelineCard {pipeline} />
+                <div class="g-col-12 g-col-md-6 g-col-xl-4">
+                    <PipelineCard {pipeline} />
+                </div>
             {/each}
         {/if}
     {:else}

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -85,6 +85,9 @@ $grid-breakpoints: (
   xxxl: 1600px,
 );
 
+// Include classes for CSS grids
+$enable-cssgrid: true;
+
 @import 'bootstrap/scss/maps';
 @import 'bootstrap/scss/mixins';
 @import 'bootstrap/scss/utilities';


### PR DESCRIPTION
Let's use that full page width, baby..

Before:

![CleanShot 2024-01-24 at 21 00 34](https://github.com/nf-core/website/assets/465550/b6017a36-ccb8-4d76-b08f-2d5ebcbac161)


After:

![CleanShot 2024-01-24 at 21 01 37](https://github.com/nf-core/website/assets/465550/e40ccdf4-c3cd-4ec4-9a73-81448514ef72)
