### PR TITLE
Add additional information for multi-tool modules

### DIFF
--- a/src/content/docs/contributing/modules.md
+++ b/src/content/docs/contributing/modules.md
@@ -611,15 +611,16 @@ The key words "MUST", "MUST NOT", "SHOULD", etc. are to be interpreted as descri
 
     For guidelines regarding multi-tool modules, please search this page for the phrase `multi-tool`.
 
-    Existing local multi-tool modules can be searched for using the Github search box searching across
-    the nf-core org, for terms such as `args2` `samtools` `collate` `fastq`.
+    Existing local multi-tool modules can be searched for using the Github search box, searching across
+    the nf-core org for terms such as `args2` `samtools` `collate` `fastq`.
 
     ```
     org:nf-core args2 samtools collate fastq
     ```
 
     Modules intended to batch process files by parallelizing repeated calls to a tool, for example with
-    `xargs` or `parallel`, also fall under the category of multi-tool modules.
+    `xargs` or `parallel`, also fall under the category of multi-tool modules. Multi-tool modules
+    should chain tools in an explicit order given by the module name, e.g. `SAMTOOLS/COLLATEFASTQ`.
     :::
 
 5.  Each tool in a multi-tool module MUST have an `$args` e.g.,

--- a/src/content/docs/contributing/modules.md
+++ b/src/content/docs/contributing/modules.md
@@ -603,6 +603,25 @@ The key words "MUST", "MUST NOT", "SHOULD", etc. are to be interpreted as descri
     bwa mem $args | samtools view $args2 -B -T ref.fasta
     ```
 
+    :::info
+    The addition of multi-tool modules to nf-core/modules adds increased burden on the nf-core
+    maintainers. Where possible, if a multi-tool module is desired, it should be implemented as
+    a local module in the nf-core pipeline. If another nf-core pipeline also desires to
+    use this module, a PR can be made adding it to nf-core/modules.
+
+    For guidelines regarding multi-tool modules, please search this page for the phrase `multi-tool`.
+
+    Existing local multi-tool modules can be searched for using the Github search box searching across
+    the nf-core org, for terms such as `args2` `samtools` `collate` `fastq`.
+
+    ```
+    org:nf-core args2 samtools collate fastq
+    ```
+
+    Modules intended to batch process files by parallelizing repeated calls to a tool, for example with
+    `xargs` or `parallel`, also fall under the category of multi-tool modules.
+    :::
+
 5.  Each tool in a multi-tool module MUST have an `$args` e.g.,
 
     ```bash

--- a/src/content/docs/contributing/modules.md
+++ b/src/content/docs/contributing/modules.md
@@ -914,6 +914,10 @@ MY_MODULE(cram, fasta)  // execution of the module will need an element in the f
 
    - Keywords MUST NOT just be solely of the (sub)tool name
 
+   :::info
+   For multi-tool modules, please add the keyword `multi-tool`, as well as all the (sub)tools involved.
+   :::
+
 3. Keywords MUST be all lower case
 
 4. The tools section MUST list every tool used in the module. For example


### PR DESCRIPTION
## Multi-tool module guidelines

- It seems there's already a lot of guidelines present for multi-tool modules.
  - Modules that optimize resource usage should therefore be referred to as multi-tool modules.
  - Fixing the term makes it easier to search for in the page since the information is scattered.
- Clever use of the Github search box should be able to help people find these modules in nf-core repositories.
  - No need to label them.
- Only allow multi-tool modules that have an explicit chain order.
  - Makes naming easier, e.g. `SAMTOOLS/COLLATEFASTQ`
  - Tools used solely for compression don't need to be in the name. e.g. `bwa mem -> samtools sort/view`.
    - How do we name modules that chain over multiple packages?

## Connected discussions

- Slack discussion: https://nfcore.slack.com/archives/C043UU89KKQ/p1702456394353949
- Example of PR that should be kept local: https://github.com/nf-core/modules/pull/4571
  - Reason for exclusion: the Groovy code is potentially too complex to understand for the average user. Pipeline developers should be able to understand quickly what a module is doing. 
- Example of PR that could be included: https://github.com/nf-core/modules/pull/3310