### PR TITLE
Update sf location on index

### DIFF
--- a/src/content/events/2024/hackathon-march-2024/index.mdx
+++ b/src/content/events/2024/hackathon-march-2024/index.mdx
@@ -85,7 +85,7 @@ Even if you are attending a local site you will still join everyone online in Ga
 | 🇬🇧 United Kingdom | London        | Cosyne Therapeutics                     | [Read more](./hackathon-march-2024/UK-London.md)                |
 | 🇬🇧 United Kingdom | Norwich       | Quadram Institute Bioscience            | [Read more](./hackathon-march-2024/UK-Norwich.md)               |
 | 🇺🇸 United States  | Dallas        | University of Texas at Dallas           | [Read more](./hackathon-march-2024/usa-utd.md)                  |
-| 🇺🇸 United States  | San Francisco | Benchling                               | [Read more](./hackathon-march-2024/usa-sanfrancisco.md)         |
+| 🇺🇸 United States  | San Francisco | Superfluid Dx                           | [Read more](./hackathon-march-2024/usa-sanfrancisco.md)         |
 | 🇺🇸 United States  | Seattle       | University of Washington                | [Read more](./hackathon-march-2024/usa-uw.md)                   |
 
 </div>


### PR DESCRIPTION
updating location of SF hackathon on the index page so it doesn't say `Benchling` anymore