### PR TITLE
Try to unconfuse stdout/err capturing

### DIFF
--- a/src/content/docs/contributing/modules.md
+++ b/src/content/docs/contributing/modules.md
@@ -773,10 +773,14 @@ The key words "MUST", "MUST NOT", "SHOULD", etc. are to be interpreted as descri
     }
     ```
 
-10. In some cases, STDOUT and STDERR need to be saved to file, for example for reporting purposes. Use the shell command `tee` to redirect the
-    streams to both file and it's original stream. This allows for the streams to be captured by the job scheduler's stream logging capabilities
-    and print them to screen when Nextflow encounters an error. In particular, when using `process.scratch`, the log files may not be preserved when
-    the job scheduler relinquishes the job allocation.
+10. In some cases, STDOUT and STDERR may need to be saved to file, for example for reporting purposes. Use
+    the shell command `tee` to capture the streams but preserve the streams. This allows for the streams to
+    be captured by the job scheduler's stream logging capabilities and print them to screen when Nextflow
+    encounters an error.
+
+    This also makes certain they are captured by Nextflow whereas things written to files only may be lost when
+    the job scheduler relinquishes the job allocation lost if using `process.scratch` - unless those files are
+    designated outputs from the process.
 
     ```nextflow {7-8}
     script:
@@ -787,6 +791,19 @@ The key words "MUST", "MUST NOT", "SHOULD", etc. are to be interpreted as descri
       --output_prefix $prefix \\
       2> >( tee ${prefix}.stderr.log >&2 ) \\
       | tee ${prefix}.stdout.log
+    """
+    ```
+
+    Similarly, if the tool captures STDOUT or STDERR to a file itself, it is best to send those to the
+    corresponding streams as well. Since a timeout may mean execution is aborted, it may make most sense
+    to have background tasks do that.
+
+    ```nextflow {7-8}
+    script:
+    """
+    tail -F stored_stderr.log >&2 &
+    tail -F stored_stdout.log &
+    tool arguments
     """
     ```
 


### PR DESCRIPTION
I found the point about capturing stdout and stderr hard to parse and confusing and have tried to make it less so.

This also adds an example of suggested behaviour when tools do not use stdout/stderr but capture such outputs to files internally.