### PR TITLE
Fix markdown block

### DIFF
--- a/bin/remark-admonitions.js
+++ b/bin/remark-admonitions.js
@@ -90,11 +90,10 @@ export default function admonitionsPlugin() {
           node.attributes.title ? node.attributes.title : boxInfo.title,
         ).properties;
 
-
         // Expand button
         let expandButton = h();
         if (node.attributes.collapse !== undefined) {
-          const expandText = 'Expand '+node.attributes.collapse;
+          const expandText = 'Expand';
           expandButton = h('button', expandText);
           const expandButtonData = expandButton.data || (expandButton.data = {});
           expandButtonData.hName = 'button';
@@ -102,11 +101,11 @@ export default function admonitionsPlugin() {
             'button',
             {
               class: `btn btn-sm text-secondary flex-shrink-1 collapsed admonition-collapse-button`,
-              type:"button",
-              "data-bs-toggle":"collapse",
-              "data-bs-target":`#admonition-${randomId}`
+              type: 'button',
+              'data-bs-toggle': 'collapse',
+              'data-bs-target': `#admonition-${randomId}`,
             },
-            expandText
+            expandText,
           ).properties;
         }
 
@@ -119,17 +118,13 @@ export default function admonitionsPlugin() {
         }).properties;
         iconWrapper.children = [svg, title, expandButton];
 
-
         // Creating the content's div for padding
         const contentColPaddingWrapper = h('div');
         const contentColPaddingWrapperData = contentColPaddingWrapper.data || (contentColPaddingWrapper.data = {});
         contentColPaddingWrapperData.hName = 'div';
-        contentColPaddingWrapperData.hProperties = h(
-          'div',
-          {
-            class: 'p-3 admonition-body-content',
-          }
-        ).properties;
+        contentColPaddingWrapperData.hProperties = h('div', {
+          class: 'p-3 admonition-body-content',
+        }).properties;
         contentColPaddingWrapper.children = [...node.children]; // Adding markdown's content block.
 
         // Creating the content's div to show/hide collapse.
@@ -137,13 +132,10 @@ export default function admonitionsPlugin() {
         const contentColWrapperData = contentColWrapper.data || (contentColWrapper.data = {});
 
         contentColWrapperData.hName = 'div';
-        contentColWrapperData.hProperties = h(
-          'div',
-          {
-            class: node.attributes.collapse !== undefined ? 'collapse' : '',
-            id:`admonition-${randomId}`
-          }
-        ).properties;
+        contentColWrapperData.hProperties = h('div', {
+          class: node.attributes.collapse !== undefined ? 'collapse' : '',
+          id: `admonition-${randomId}`,
+        }).properties;
         contentColWrapper.children = [contentColPaddingWrapper];
 
         // Creating the wrapper for the admonition's content.

--- a/bin/remark-admonitions.js
+++ b/bin/remark-admonitions.js
@@ -120,8 +120,6 @@ export default function admonitionsPlugin() {
         iconWrapper.children = [svg, title, expandButton];
 
 
-
-
         // Creating the content's div for padding
         const contentColPaddingWrapper = h('div');
         const contentColPaddingWrapperData = contentColPaddingWrapper.data || (contentColPaddingWrapper.data = {});
@@ -129,7 +127,7 @@ export default function admonitionsPlugin() {
         contentColPaddingWrapperData.hProperties = h(
           'div',
           {
-            class: 'p-3',
+            class: 'p-3 admonition-body-content',
           }
         ).properties;
         contentColPaddingWrapper.children = [...node.children]; // Adding markdown's content block.

--- a/bin/remark-admonitions.js
+++ b/bin/remark-admonitions.js
@@ -46,6 +46,7 @@ export default function admonitionsPlugin() {
           return;
         }
 
+        const randomId = (Math.random() + 1).toString(36).substring(7);
         const boxInfo = acceptableAdmonitionTypes[node.name];
         // Adding CSS classes according to the type.
         const data = node.data || (node.data = {});
@@ -85,25 +86,67 @@ export default function admonitionsPlugin() {
         titleData.hName = 'span';
         titleData.hProperties = h(
           'span',
-          { class: `admonition-title ` },
+          { class: `admonition-title flex-grow-1 ` },
           node.attributes.title ? node.attributes.title : boxInfo.title,
         ).properties;
+
+
+        // Expand button
+        let expandButton = h();
+        if (node.attributes.collapse !== undefined) {
+          const expandText = 'Expand '+node.attributes.collapse;
+          expandButton = h('button', expandText);
+          const expandButtonData = expandButton.data || (expandButton.data = {});
+          expandButtonData.hName = 'button';
+          expandButtonData.hProperties = h(
+            'button',
+            {
+              class: `btn btn-sm text-secondary flex-shrink-1 collapsed admonition-collapse-button`,
+              type:"button",
+              "data-bs-toggle":"collapse",
+              "data-bs-target":`#admonition-${randomId}`
+            },
+            expandText
+          ).properties;
+        }
 
         // Creating the icon's column.
         const iconWrapper = h('div');
         const iconWrapperData = iconWrapper.data || (iconWrapper.data = {});
         iconWrapperData.hName = 'div';
         iconWrapperData.hProperties = h('div', {
-          class: `title alert alert-${boxInfo.id} fw-bold px-3 py-2 d-flex align-items-center rounded-0 border-0`,
+          class: `title mb-0 alert alert-${boxInfo.id} fw-bold px-3 py-2 d-flex align-items-center rounded-0 border-0`,
         }).properties;
-        iconWrapper.children = [svg, title];
+        iconWrapper.children = [svg, title, expandButton];
 
-        // Creating the content's column.
+
+
+
+        // Creating the content's div for padding
+        const contentColPaddingWrapper = h('div');
+        const contentColPaddingWrapperData = contentColPaddingWrapper.data || (contentColPaddingWrapper.data = {});
+        contentColPaddingWrapperData.hName = 'div';
+        contentColPaddingWrapperData.hProperties = h(
+          'div',
+          {
+            class: 'p-3',
+          }
+        ).properties;
+        contentColPaddingWrapper.children = [...node.children]; // Adding markdown's content block.
+
+        // Creating the content's div to show/hide collapse.
         const contentColWrapper = h('div');
         const contentColWrapperData = contentColWrapper.data || (contentColWrapper.data = {});
+
         contentColWrapperData.hName = 'div';
-        contentColWrapperData.hProperties = h('div', { class: 'p-3 pt-0' }).properties;
-        contentColWrapper.children = [...node.children]; // Adding markdown's content block.
+        contentColWrapperData.hProperties = h(
+          'div',
+          {
+            class: node.attributes.collapse !== undefined ? 'collapse' : '',
+            id:`admonition-${randomId}`
+          }
+        ).properties;
+        contentColWrapper.children = [contentColPaddingWrapper];
 
         // Creating the wrapper for the admonition's content.
         const contentWrapper = h('div');

--- a/src/content/docs/contributing/tutorials/dsl2_modules_tutorial.md
+++ b/src/content/docs/contributing/tutorials/dsl2_modules_tutorial.md
@@ -32,7 +32,7 @@ If you _must_ create your own test data, make sure you follow the [test data gui
 
 The first step, to contribute a module to the community repository is to fork \*nf-core modules into your own account or organisation. To do this, you should click on the top-right of the nf-core modules repository, and choose "fork" as shown in the figure below.
 
-![fork](/assets/markdown_assets/contributing/dsl2_modules_tutorial/dsl2-mod_01_fork.png)
+![fork](/images/contributing/dsl2_modules_tutorial/dsl2-mod_01_fork.png)
 
 You then choose the account or organisation you want to fork the repository into. Once forked, you can commit all changes you need into the new repository.
 
@@ -52,7 +52,7 @@ In order to create a new module, it is best to branch the code into a recognisab
 
   - To do this, you can select the dropdown menu on the top-left of your repository code, write the name of the new branch and choose to create it as shown below:
 
-    ![branch](/assets/markdown_assets/contributing/dsl2_modules_tutorial/dsl2-mod_02_new_branch.png)
+    ![branch](/images/contributing/dsl2_modules_tutorial/dsl2-mod_02_new_branch.png)
 
   - You will then sync this locally (ideally, you clone the forked repository on your working environment to edit code more comfortably)
 
@@ -100,7 +100,7 @@ Each of the files is pre-filled according to a defined nf-core template.
 
 You fill find a number of commented sections in the file, to help you modify the code while adhering to the guidelines, as you can appreciate in the following figure.
 
-```nextflow
+```groovy
 // TODO nf-core: If in doubt look at other nf-core/modules to see how we are doing things! :)
 //               https://github.com/nf-core/modules/tree/master/modules
 //               You can also ask for help via your pull request or on the #modules channel on the nf-core Slack workspace:
@@ -186,7 +186,7 @@ In our case, FGBIO also has a mandatory argument, which is not sample-specific, 
 
 Therefore, once we modify the template accordingly, our inputs and outputs will look like this:
 
-```nextflow
+```groovy
 input:
     tuple val(meta), path(reads)
     val(read_structure)
@@ -212,13 +212,13 @@ We now can substitute all our parameters with our predefined inputs, outputs and
 mkdir tmpFolder
 
 fgbio --tmp-dir=${PWD}/tmpFolder \\
-FastqToBam \\
-$args \\
--i ${reads} \\
--o "${prefix}_umi_converted.bam" \\
---read-structures $read_structure \\
---sample ${meta.id} \\
---library ${meta.id}
+    FastqToBam \\
+    $args \\
+    -i ${reads} \\
+    -o "${prefix}_umi_converted.bam" \\
+    --read-structures $read_structure \\
+    --sample ${meta.id} \\
+    --library ${meta.id}
 ```
 
 ### Export the version of the tool
@@ -246,7 +246,7 @@ However, in some cases the software outputs the version as _stderr_ and causes a
 
 In order to avoid that, we can in general print the version as part of an echo statement, like this
 
-```nextflow
+```groovy
 echo \$(tool --version 2>&1)
 ```
 
@@ -258,26 +258,27 @@ tool --version |& sed 'pattern'
 
 Notice the escape `\$` of the first `$` sign to distinguish between _bash_ variables and _nextflow_ variables.
 
-      <details markdown="1">
-      <summary>Tips</summary>
-      - `sed '3!d'` Extracts only line 3 of the output printed by `samtools --version`
-      - Determine whether the error printed to stderr or stdout, by trying to filter the line with `sed`
+:::tip{collapse}
 
-      ```bash
-      samtools --version
-      # Try filtering the specific line
-      samtools --version | sed '1!d'
-      ```
+- `sed '3!d'` Extracts only line 3 of the output printed by `samtools --version`
+- Determine whether the error printed to stderr or stdout, by trying to filter the line with `sed`
 
-      - If it works, then you're reading from stdout, otherwise you need to capture stderr using `|&` which is shorthand for `2>&1 |`
-      - `sed 's/pattern/replacement/'` can be used to remove parts of a string. `.` matches any character, `+` matches 1 or more times.
-      - You can separate sed commands using `;`. Often the pattern : `sed filter line ; replace string` is enough to get the version number
-      - It is not necessary to use `echo`
-      - For non-zero error code: `command --version || true` or  `command --version | sed ... || true`
-      - If the version is at a specific line you can try `sed -nr '/pattern/p'` that will return only the line with the pattern
-      - To extract the version number in the middle you can also use regex pattern with `grep` as follow: `grep -o -E '([0-9]+.){1,2}[0-9]'`
-      - If multiple lines are returned you can select the first one with `tool --version | head -n 1`
-      </details>
+```bash
+samtools --version
+# Try filtering the specific line
+samtools --version | sed '1!d'
+```
+
+- If it works, then you're reading from stdout, otherwise you need to capture stderr using `|&` which is shorthand for `2>&1 |`
+- `sed 's/pattern/replacement/'` can be used to remove parts of a string. `.` matches any character, `+` matches 1 or more times.
+- You can separate sed commands using `;`. Often the pattern : `sed filter line ; replace string` is enough to get the version number
+- It is not necessary to use `echo`
+- For non-zero error code: `command --version || true` or `command --version | sed ... || true`
+- If the version is at a specific line you can try `sed -nr '/pattern/p'` that will return only the line with the pattern
+- To extract the version number in the middle you can also use regex pattern with `grep` as follow: `grep -o -E '([0-9]+.){1,2}[0-9]'`
+- If multiple lines are returned you can select the first one with `tool --version | head -n 1`
+
+:::
 
 Unfortunately, FGBIO manages to cause an error exit even with this solution, and we are therefore forced to use a few `bash` tricks to re-route the version and format it to be _just_ the semantic number.
 
@@ -292,7 +293,7 @@ This may take a bit of time to get right.
 
 Once that's complete, our final script will therefore look like this:
 
-```nextflow
+```groovy
 process FGBIO_FASTQTOBAM {
     tag "$meta.id"
     label 'process_low'
@@ -338,7 +339,9 @@ process FGBIO_FASTQTOBAM {
 }
 ```
 
-> :heavy_check_mark: It is always good practice to commit regularly while you write the code and comment the commit with a meaningful message. This way, you will always be able to revert the changes at any time.
+:::note
+It is always good practice to commit regularly while you write the code and comment the commit with a meaningful message. This way, you will always be able to revert the changes at any time.
+:::
 
 ### Fill in the meta.yaml
 
@@ -346,17 +349,17 @@ Once the main module code is written, it is often a good point to fill in the `m
 
 Here you will document key words, context information about the module, and most importantly document the input and output requirements. In general, it follows a similar shape as the pipeline schema but is no JSON file. At the top you should add the name of the module, a short description and at least three keywords, which describe the module. Afterwards, describe all used tools, usually only one. The main part of the `meta.yml` should be about the input and output requirements, which follow the same fields as the pipeline schema for a file parameter. For each input and output requirement you have to add a type, a short description about the content and a pattern. The last block contains the authors, who worked on the module, to allow other users to easily reach out to them. If you are the main developer of the module, your GitHub name will be automatically added to the `meta.yml`. The types in the `meta.yml` are limited to map, file, directory, string, integer and float. In this example module, the prebuild `meta.yml` is already filled and the input part looks as follows:
 
-```nextflow
-## TODO nf-core: Add a description of all of the variables used as input
+```groovy
+// TODO nf-core: Add a description of all of the variables used as input
 input:
-  # Only when we have meta
+  // Only when we have meta
   - meta:
       type: map
       description: |
         Groovy Map containing sample information
         e.g. [ id:'test', single_end:false ]
-  #
-  ## TODO nf-core: Delete / customise this example input
+
+  // TODO nf-core: Delete / customise this example input
   - bam:
       type: file
       description: BAM/CRAM/SAM file
@@ -377,7 +380,7 @@ nf-core modules lint fgbio/demofastqtobam
 
 You will expect no test failed, as shown in figure below:
 
-![lint](/assets/markdown_assets/contributing/dsl2_modules_tutorial/dsl2-mod_04_lint_module.png)
+![lint](/images/contributing/dsl2_modules_tutorial/dsl2-mod_04_lint_module.png)
 
 For more information on fixing linting errors in your code both locally and directly in your pull request in GitHub, check at the end of this subsection [here](https://nf-co.re/docs/usage/tutorials/nf_core_usage_tutorial#installing-the-nf-core-helper-tools).
 
@@ -414,11 +417,11 @@ Once all your tests are passing - it's time to submit the module to nf-core/modu
 
 Back on GitHub, creating a Pull Request is very simple: on the top right of your repository you can click on the link "Pull request" as shown in the figure below:
 
-![pull](/assets/markdown_assets/contributing/dsl2_modules_tutorial/dsl2-mod_06_pull-reqs.png)
+![pull](/images/contributing/dsl2_modules_tutorial/dsl2-mod_06_pull-reqs.png)
 
 If you have initiated the pull request from your forked repository, the direction of the request should be indicated by the arrow, as in the picture below, i.e. from your fork to the nf-core original repository
 
-![open_pull](/assets/markdown_assets/contributing/dsl2_modules_tutorial/dsl2-mod_07_pull-reqs-open.png)
+![open_pull](/images/contributing/dsl2_modules_tutorial/dsl2-mod_07_pull-reqs-open.png)
 
 You can find more information on the GitHub [guide](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) and the nf-core talk [_Bytesize 4: GitHub contribution basics_](https://nf-co.re/events/2021/bytesize-4-github-contribution-basics).
 

--- a/src/content/docs/contributing/website_markdown.md
+++ b/src/content/docs/contributing/website_markdown.md
@@ -117,6 +117,18 @@ Curiously enough, the only thing that went through the mind of the bowl of petun
 Curiously enough, the only thing that went through the mind of the bowl of petunias as it fell was Oh no, not again.
 :::
 
+## Collapsing admonitions
+
+```md
+:::note{collapse}
+Many people have speculated that if we knew exactly why the bowl of petunias had thought that we would know a lot more about the nature of the Universe than we do now.
+:::
+```
+
+:::note{collapse}
+Many people have speculated that if we knew exactly why the bowl of petunias had thought that we would know a lot more about the nature of the Universe than we do now.
+:::
+
 # Code blocks
 
 We use [rehype-pretty-code](https://rehype-pretty-code.netlify.app/) to generate code blocks on the website. This allows us to add line numbers, highlight lines, add file names to code blocks, etc. These directives can be mixed and matched.

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -77,6 +77,24 @@ blockquote {
   }
 }
 
+.main-content figure pre:has(+ figcaption) {
+  margin-bottom: 0;
+}
+.main-content figure pre:has(+ figcaption) code {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.main-content figcaption {
+  font-size: 0.8rem;
+  color: $body-secondary-color;
+  margin-bottom:1.5rem;
+  padding: 0.2rem 0.5rem;
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
+  border: 1px solid $border-color;
+  border-top: 0;
+}
+
 mark,
 .mark {
   padding: 0.2em 0;
@@ -1461,6 +1479,10 @@ div.mermaid {
 
   .main-content pre code {
     border: 1px solid $border-color-dark;
+  }
+  .main-content figcaption {
+    border-color: $border-color-dark;
+    color: $body-secondary-color-dark;
   }
 
   .markdown-content img[alt='Workflow'] {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1292,6 +1292,20 @@ Launch Page
   .title {
     margin-bottom: 0.9rem;
   }
+  .admonition-collapse-button::after {
+    display: inline-block;
+    font-style: normal;
+    font-variant: normal;
+    text-rendering: auto;
+    -webkit-font-smoothing: antialiased;
+    font-family: "Font Awesome 6 Pro", "Font Awesome 6 Pro fallback";
+    margin-left: 0.5rem;
+    font-weight: 900;
+    content: "\f078";
+  }
+  .admonition-collapse-button.collapsed::after {
+    content: "\f054";
+  }
 }
 
 figure[data-rehype-pretty-code-figure] [data-theme*=' ']:not([data-rehype-pretty-code-title]) {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -87,12 +87,14 @@ blockquote {
 .main-content figcaption {
   font-size: 0.8rem;
   color: $body-secondary-color;
-  margin-bottom:1.5rem;
   padding: 0.2rem 0.5rem;
-  border-bottom-left-radius: 3px;
-  border-bottom-right-radius: 3px;
   border: 1px solid $border-color;
   border-top: 0;
+}
+.main-content figcaption::last-child {
+  margin-bottom: 1.5rem;
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
 }
 
 mark,

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1306,6 +1306,9 @@ Launch Page
   .admonition-collapse-button.collapsed::after {
     content: "\f054";
   }
+  .admonition-body-content {
+    font-size: 90%;
+  }
 }
 
 figure[data-rehype-pretty-code-figure] [data-theme*=' ']:not([data-rehype-pretty-code-title]) {


### PR DESCRIPTION
<img src="https://github.com/nf-core/website/assets/465550/dc12daed-8264-4b3b-86ad-56c1a8c55eb9" width=300>

---

Spotted some badly rendered old markdown, so went in to fix it. It needed to be an admonition, then it had an ugly `<details>` block inside. Figured that we should have admonitions that can be collapsed (like mkdocs material), but realised that we didn't have any.

Skip forward several hours, now we have this:

![CleanShot 2024-03-21 at 16 36 08](https://github.com/nf-core/website/assets/465550/c57ac185-f647-49ca-8e54-59fc76808c59)

Whilst I was there, I noticed that code block captions were unstyled. So I also styled them:

![CleanShot 2024-03-21 at 16 38 07@2x](https://github.com/nf-core/website/assets/465550/0c79416f-aa5e-442a-98ca-85344e7c4202)

I also did a handful of other tweaks, such as making the body text of admonitions 90% font size.