### PR TITLE
Blog: Make images in cards clickable too

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -106,7 +106,7 @@ const sections = years.map((year) => {
                                             transition:name="cover-image"
                                         />
                                     )}
-                                    <div class="card-body position-relative">
+                                    <div class="card-body">
                                         <h2 transition:name="title">{post.data.title}</h2>
                                         <p class="lead">{post.data.subtitle}</p>
                                         <p class="card-text small">


### PR DESCRIPTION
Remove relative class to make stretched link apply to image too.