### PR TITLE
Push the announcement date for Boston hackathon

### DIFF
--- a/src/content/events/2024/hackathon-boston.mdx
+++ b/src/content/events/2024/hackathon-boston.mdx
@@ -3,7 +3,7 @@ title: Hackathon - May 2024 (Boston)
 subtitle: An in-person hackathon held in Boston
 type: hackathon
 announcement:
-    start: 2024-03-30T12:00:00-05:00
+    start: 2024-04-22T12:00:00-05:00
 startDate: '2024-05-21'
 startTime: '10:00-04:00'
 endDate: '2024-05-22'


### PR DESCRIPTION
I feel like this is too far off, if this banner is _always_ there then people will start to ignore it 😆

@netlify /events/2024/hackathon-boston