### PR TITLE
Tweak installation reading flow guidance

### DIFF
--- a/src/content/docs/usage/installation.md
+++ b/src/content/docs/usage/installation.md
@@ -14,7 +14,7 @@ This makes it easier to update and control versions.
 We generally recommend following the official installation instructions from the Nextflow documentation.
 However on this page we provide '[quick start](#quick-start-installation)' version of these instructions, as well as instructions for [installing via Conda](#bioconda-instllation), and on [Windows operating systems](#installation-on-windows).
 
-At any point, if double, see the [official Nextflow installation documentation](https://www.nextflow.io/docs/latest/getstarted.html#installation).
+If in doubt, see the [official Nextflow installation documentation](https://www.nextflow.io/docs/latest/getstarted.html#installation).
 Any instructions on this page are provided for convinence, and may not be up-to-date.
 
 :::note

--- a/src/content/docs/usage/installation.md
+++ b/src/content/docs/usage/installation.md
@@ -11,11 +11,11 @@ All nf-core pipelines use Nextflow, so this must be installed on the system wher
 We recommend using a personal installation of Nextflow where possible, instead of using a system-wide installation.
 This makes it easier to update and control versions.
 
-:::tip{collapse title="Official Nextflow docs"}
-If in doubt, please see the [Nextflow installation docs](https://www.nextflow.io/docs/latest/getstarted.html#installation)
-for the latest instructions.
-Installation details are included here for convenience and may not be up to date.
-:::
+We generally recommend following the official installation instructions from the Nextflow documentation.
+However on this page we provide '[quick start](#quick-start-installation)' version of these instructions, as well as instructions for [installing via Conda](#bioconda-instllation), and on [Windows operating systems](#installation-on-windows).
+
+At any point, if double, see the [official Nextflow installation documentation](https://www.nextflow.io/docs/latest/getstarted.html#installation).
+Any instructions on this page are provided for convinence, and may not be up-to-date.
 
 :::note
 You don't need to install the `nf-core` command line tools to run nf-core pipelines, you only need Nextflow.
@@ -23,7 +23,11 @@ However, they offer a number of helpful functions and are essential for pipeline
 See the [tools page](/tools) for more information.
 :::
 
-### Typical installation
+### Official Nextflow installation.
+
+The Nextflow installation docs can be found [here](https://www.nextflow.io/docs/latest/getstarted.html#installation) for the latest instructions.
+
+### Quick-start installation
 
 Nextflow runs on most POSIX systems (Linux, macOS, etc) and can typically be installed by running these commands:
 


### PR DESCRIPTION
@ewels this is what I was referring to before basically (sorry previous review was from my phone).

Basically you generally want people to follow the official Nextflow docs, but you hid this away in the collapsed box (and missed that it was collapsed during the review).

However then you give the instructions later anyway. Furthermore, at this point someone may have followed the official installation documentation and mess around with `bins/` and `$PATHS` to then come back to the official documentation to find out they could've installed via bioconda (for example).

I would rather make the intro more explicit to guide people what options there are and what we recommend etc.

@netlify /docs/usage/installation