### PR TITLE
Hackathon 2025 - Add event placeholder to save the date.

### DIFF
--- a/src/content/events/2025/hackathon-march-2025/index.mdx
+++ b/src/content/events/2025/hackathon-march-2025/index.mdx
@@ -1,0 +1,24 @@
+---
+title: Hackathon - March 2025 (Online / Distributed)
+subtitle: A virtual hackathon with local sites to develop nf-core together
+type: hackathon
+startDate: '2024-03-24'
+startTime: '10:00+02:00'
+endDate: '2024-03-26'
+endTime: '17:00+02:00'
+locations:
+    - name: Gather town, Slack, and local sites.
+# importTypeform: true
+announcement:
+    text: 'Registration for the online / distributed March hackathon is now open!'
+    start: 2025-02-22T00:00:00+01:00
+    end: 2025-03-23T00:00:00+01:00
+---
+
+# Welcome
+
+Join us online and in person **March 24-26, 2025**, for the nf-core hackathon! 🗓️
+
+The plan is to do an online + distributed hackathon, as held in [2023](/events/2023/hackathon-march-2023) and [2024](/events/2024/hackathon-march-2024).
+
+For now this is just a placeholder to save the date. Check back soon for more details!


### PR DESCRIPTION
Placeholder event for 2025.

Draft state for now until dates given the ok from a few more folks.

@netlify /events/2025/hackathon-march-2025