### PR TITLE
Add pipeline level nf-test documentation

### DIFF
--- a/src/content/docs/guidelines/pipelines/overview.md
+++ b/src/content/docs/guidelines/pipelines/overview.md
@@ -51,6 +51,7 @@ All nf-core pipelines _should_ follow the following guidelines, if possible / ap
 
 - [Use Bioconda](/docs/guidelines/pipelines/recommendations/bioconda): Package software using bioconda and biocontainers.
 - [File formats](/docs/guidelines/pipelines/recommendations/file_formats): Use community accepted modern file formats such as `CRAM`.
+- [Testing](/docs/guidelines/pipelines/recommendations/testing): Use nf-test to test pipeline completes successfully with valid outputs using a minimal example.
 - [DOIs](/docs/guidelines/pipelines/recommendations/dois): Pipelines should have digital object identifiers (DOIs).
 - [Cloud compatible](/docs/guidelines/pipelines/recommendations/cloud_compatible): Pipelines should be tested on cloud computing environments.
 - [Publication credit](/docs/guidelines/pipelines/recommendations/publication_credit): Pipeline publications should acknowledge the nf-core community.

--- a/src/content/docs/guidelines/pipelines/recommendations/testing.md
+++ b/src/content/docs/guidelines/pipelines/recommendations/testing.md
@@ -1,0 +1,11 @@
+---
+title: Testing
+subtitle: Use nf-test to validate pipeline
+menu:
+  main:
+    weight: 210
+---
+
+Pipelines should use nf-test for valid pipeline testing.
+
+All pipelines should support nf-test and use it for pipeline level tests. Additional tests for local subworkflows and modules is recommended. Modules and subworkflows from nf-core/modules should include nf-tests which can also be used within the pipeline.

--- a/src/content/docs/guidelines/pipelines/recommendations/testing.md
+++ b/src/content/docs/guidelines/pipelines/recommendations/testing.md
@@ -1,9 +1,7 @@
 ---
 title: Testing
 subtitle: Use nf-test to validate pipeline
-menu:
-  main:
-    weight: 210
+weight: 210
 ---
 
 Pipelines should use nf-test for valid pipeline testing.

--- a/src/content/docs/tutorials/tests_and_test_data/nf-test_writing_tests.md
+++ b/src/content/docs/tutorials/tests_and_test_data/nf-test_writing_tests.md
@@ -130,3 +130,29 @@ nextflow_process {
     }
 }
 ```
+
+## nf-test guidelines for pipelines
+
+Pipeline level tests can facilitate more reliable and reproducible pipelines by ensuring the pipeline produces identical results with every run. You must add pipeline tests that work with `-profile test` and you should reuse this profile within one nf-test.
+
+### Pipeline nf-test overview and structure
+
+Within the base directory of the repository, there is a configuration file for nf-test, named `nf-test.config`. This will set the following options:
+
+- Set the testsDir to the base of the repository so it includes all files
+- Set the default profile(s) for nf-test to include `test` (this can be overridden on the command line)
+- Add an additional configuration file specific for nf-test located in `tests/nextflow.config`
+
+Within the nf-test specific configuration file, you can add specific requirements for running nf-tests but this should not include parameters or options as these should be available in all contexts.
+
+Pipeline level tests are located in the `tests` directory. Each nf-test file must contain a single pipeline test which tests for a single scenario. Although nf-test supports multiple tests within a single nf-test file, keeping thme in separate files makes it easier to launch individual pipeline tests. Each nf-test file should be named after the scenario it tests in the following format:
+
+- `tests/scenarioA.main.nf.test`
+- `tests/scenarioB.main.nf.test`
+
+### Pipeline nf-tests additional guidance
+
+The same guidelines for test profiles, test data and nf-test also apply to pipeline tests. In addition, the following guidelines apply:
+
+- To ensure all output files are caught, the `params.outdir` should be set the the nf-test variable `outputDir`
+- The tag `PIPELINE` and the pipeline name should be added to all tests


### PR DESCRIPTION
Adds documentation for nf-tests at the pipeline level.

@netlify /docs/guidelines/pipelines/recommendations/testing