### PR TITLE
Change version to versions on assertions page (fix)

### DIFF
--- a/src/content/docs/contributing/nf-test/assertions.md
+++ b/src/content/docs/contributing/nf-test/assertions.md
@@ -83,7 +83,7 @@ log[0][1]
 ```groovy
 assertAll(
     { assert process.success },
-    { assert snapshot(process.out.version).match("version") }
+    { assert snapshot(process.out.versions).match("versions") }
 )
 ```
 


### PR DESCRIPTION
Fixes the nf-test assertions documentation showing "version" instead of "versions" in the assertion requirements.

@netlify /docs/contributing/nf-test/assertions