### PR TITLE
Renovate automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
     $schema: "https://docs.renovatebot.com/renovate-schema.json",
-    extends: ["github>nf-core/ops//.github/renovate/default.json5", "config:recommended", "schedule:monthly"],
+    extends: ["github>nf-core/ops//.github/renovate/default.json5", "config:js-app", "schedule:monthly"],
     customManagers: [
         {
             customType: "regex",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,13 +8,13 @@
             matchStrings: ["https://github.com/(?<depName>.*)/releases/download/(?<currentValue>.*)/.*.tar.gz"],
             datasourceTemplate: "github-release-attachments"
         }
-    ]
+    ],
     "packageRules": [
         {
             "packageName": "*",
             "dependencyType": "direct",
             "manager": "npm",
-            "enabled": false
+            "automerge": false
         }
     ]
 }

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+      # https://docs.renovatebot.com/key-concepts/automerge/#branch-vs-pr-automerging
+      - 'renovate/**' # branches Renovate creates
   pull_request:
 
 jobs:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,5 +1,9 @@
 name: Playwright Tests
 on:
+  push:
+    branches:
+      # https://docs.renovatebot.com/key-concepts/automerge/#branch-vs-pr-automerging
+      - 'renovate/**' # branches Renovate creates
   pull_request:
 
 # Cancel if a newer run is started


### PR DESCRIPTION
Making a draft to discuss.

Would automerge most updates on their own. We can exclude anything that breaks stuff commonly and make those raise a PR, but linters, types, GitHub actions will get merged automatically.