### PR TITLE
VSCode admonition styling using 'Markdown Extended'

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "markdown.styles": [
+    "public/vscode_markdown.css"
+  ]
+}

--- a/public/vscode_markdown.css
+++ b/public/vscode_markdown.css
@@ -1,0 +1,30 @@
+.note {
+  border-radius: .25rem;
+  border: 2px solid #084298;
+  padding: 1rem 1rem 0;
+  margin-bottom: 1rem;
+}
+.info {
+  border-radius: .25rem;
+  border: 2px solid #0e616e;
+  padding: 1rem 1rem 0;
+  margin-bottom: 1rem;
+}
+.tip {
+  border-radius: .25rem;
+  border: 2px solid #14683b;
+  padding: 1rem 1rem 0;
+  margin-bottom: 1rem;
+}
+.warning {
+  border-radius: .25rem;
+  border: 2px solid #997404;
+  padding: 1rem 1rem 0;
+  margin-bottom: 1rem;
+}
+.danger {
+  border-radius: .25rem;
+  border: 2px solid #842029;
+  padding: 1rem 1rem 0;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
Use https://github.com/qjebbs/vscode-markdown-extended to render admonitions in VSCode.

Requires this extension:

* Name: Markdown Extended
* Id: `jebbs.markdown-extended`
* Description: Extended syntaxes to built-in markdown & What you see is what you get exporter.
* Version: `1.1.4`
* Publisher: `jebbs`
* VS Marketplace Link: https://marketplace.visualstudio.com/items?itemName=jebbs.markdown-extended

Then does an imperfect but not-too-bad job of rendering admonitions in markdown previews in VSCode:

![CleanShot 2024-06-12 at 17 14 32@2x](https://github.com/nf-core/website/assets/465550/0fbb753f-f62d-4b12-856f-6b1bc113ef83)

Currently set to use workspace VSCode settings. This won't work when writing docs in pipeline repos. If we want to do that, we'll need to use a https URL to the stylesheet (not a problem once this is merged) and then add a `.vscode` directory to the template with this settings file (which I like less).

'cc @FloWuenne @mahesh-panchal 