### PR TITLE
Join: admonition for expired slack invite link

### DIFF
--- a/sites/main-site/src/pages/join.astro
+++ b/sites/main-site/src/pages/join.astro
@@ -145,7 +145,7 @@ const headings = [
             ><i class="fab fa-slack"></i> Get an invite to nf-core Slack</a
         >
     </p>
-    <div class="alert alert-secondary text-center">
+    <div class="alert alert-secondary text-center small">
         If the invite link doesn't work, please email us at
         <a href="mailto:core@nf-co.re">core@nf-co.re</a> so that we can update it. Thanks!
     </div>

--- a/sites/main-site/src/pages/join.astro
+++ b/sites/main-site/src/pages/join.astro
@@ -145,8 +145,8 @@ const headings = [
             ><i class="fab fa-slack"></i> Get an invite to nf-core Slack</a
         >
     </p>
-    <div class="alert alert-info text-center">
-        If the invite link doesn't work because it has expired, please email us at
+    <div class="alert alert-secondary text-center">
+        If the invite link doesn't work, please email us at
         <a href="mailto:core@nf-co.re">core@nf-co.re</a> so that we can update it. Thanks!
     </div>
 

--- a/sites/main-site/src/pages/join.astro
+++ b/sites/main-site/src/pages/join.astro
@@ -145,6 +145,10 @@ const headings = [
             ><i class="fab fa-slack"></i> Get an invite to nf-core Slack</a
         >
     </p>
+    <div class="alert alert-info text-center">
+        If the invite link doesn't work because it has expired, please email us at
+        <a href="mailto:core@nf-co.re">core@nf-co.re</a> so that we can update it. Thanks!
+    </div>
 
     <h1 id="github" class="mt-5">
         <span class="join-pull-img bg-body"><Icon name="fa:github" class="text-body" size="120px" /></span>


### PR DESCRIPTION
Add a small box saying what to do if the slack invite link doesn't work, as this is a pretty common thing now.

@netlify /join