### PR TITLE
Use auto overflow for profile names

### DIFF
--- a/sites/main-site/src/components/GitHubProfilePicture.svelte
+++ b/sites/main-site/src/components/GitHubProfilePicture.svelte
@@ -35,7 +35,7 @@
             style="--size:{size};"
             class={' ' + imgClasses}
         />
-        <div class="profile-name text-nowrap overflow-x-scroll">
+        <div class="profile-name text-nowrap overflow-x-auto">
             <slot />
         </div>
     </a>


### PR DESCRIPTION
This should prevent displaying scrollbars when they are not needed, like here:
![image](https://github.com/user-attachments/assets/d53710ec-a2e8-4424-991e-a48263a48397)

The auto overflow should still display the scrollbar whenever needed, as described [here](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x#auto).

I think this looks more beautiful, but if there was a rationale behind the original implementation, let me know.