### PR TITLE
Modules params: Tolerate missing description strings

### DIFF
--- a/sites/main-site/src/components/component/ComponentParamTable.astro
+++ b/sites/main-site/src/components/component/ComponentParamTable.astro
@@ -52,7 +52,7 @@ export interface Props {
                     </div>
 
                     <div class={'col-12 description py-1 small col-md-' + (pattern ? '5' : '7')}>
-                        <Markdown of={description.replace(/(\n)/g, '  \n').replace(/\*./g, '\\*.')} />
+                        <Markdown of={description?.replace(/(\n)/g, '  \n').replace(/\*./g, '\\*.')} />
                     </div>
                     <div class={'col-12 col-md-' + (pattern ? '4' : '1') + ' ms-auto'}>
                         {pattern && <code class="float-end pattern">{pattern}</code>}


### PR DESCRIPTION
For upcoming module updates.

Hotfix - doesn't properly render the new nested arrays, but at least prevents the page from crashing hard.

Should tide us over for a few days until @mashehu gets back and works his magic to make this work properly 😬 

Unblocks @mirpedrol to merge her module update PRs.