### PR TITLE
Don't collapse so many admonitions

### DIFF
--- a/sites/main-site/src/content/blog/2024/seqera-containers-part-1.mdx
+++ b/sites/main-site/src/content/blog/2024/seqera-containers-part-1.mdx
@@ -135,7 +135,7 @@ Building on-demand gives greater flexibility and scalability, especially for mul
 nf-core pipeline users won't need to interact with Wave directly.
 We simply plan to replace the mechanism for supplying the default container images specified in pipelines.
 
-:::info{.fa-list-check title="Feature comparison" collapse}
+:::info{.fa-list-check title="Feature comparison"}
 
 It's important to distinguish the differences between Wave and Seqera Containers.
 Here's a brief comparison of the features:
@@ -276,7 +276,7 @@ Unfortunately, generating mulled containers is not trivial.
 
 </div>
 
-:::tip{title="How to make a mulled BioContainer" collapse}
+:::tip{title="How to make a mulled BioContainer"}
 Luke Pembleton, Nextflow Ambassador, has a great blog post summarising the dark art of
 [Finding the right mulled biocontainer](https://lpembleton.rbind.io/posts/mulled-biocontainers/).
 Galaxy also has [documentation on the topic](https://docs.galaxyproject.org/en/master/admin/container_resolvers.html).


### PR DESCRIPTION
I collapsed basically all admonitions on this blog post to try to make it shorter. But I think it was a bit much. Just scanned over it like, 3 times looking for the feature comparison table.

Switched two admonitions here which were shorter / more central to the story to be expanded by default.