### PR TITLE
Fix the JSON schema link in nf-core components page

### DIFF
--- a/sites/docs/src/content/docs/tutorials/nf-core_components/components.mdx
+++ b/sites/docs/src/content/docs/tutorials/nf-core_components/components.mdx
@@ -79,7 +79,7 @@ and proceed with Step 5.
 
     2. [`./modules/nf-core/fastqc/meta.yml`](https://github.com/nf-core/modules/blob/master/modules/nf-core/fastqc/meta.yml)
 
-        This file will be used to store general information about the module and author details - the majority of which will already be auto-filled. However, you will need to add a brief description of the files defined in the `input` and `output` section of the main script since these will be unique to each module. We check it's formatting and validity based on a [JSON schema](https://github.com/nf-core/modules/blob/master/.yaml-schema.json) during linting (and in the pre-commit hook).
+        This file will be used to store general information about the module and author details - the majority of which will already be auto-filled. However, you will need to add a brief description of the files defined in the `input` and `output` section of the main script since these will be unique to each module. We check it's formatting and validity based on a [JSON schema](https://github.com/nf-core/modules/blob/master/modules/meta-schema.json) during linting (and in the pre-commit hook).
 
     3. [`./modules/nf-core/fastqc/tests/main.nf.test`](https://github.com/nf-core/modules/blob/master/modules/nf-core/fastqc/tests/main.nf.test)
 


### PR DESCRIPTION
This PR fixes the broken link in nf-core components page: https://nf-co.re/docs/tutorials/nf-core_components/components
