### PR TITLE
added folder structure for usage tutorial

### DIFF
--- a/public/pipelines.json
+++ b/public/pipelines.json
@@ -37845,7 +37845,11 @@
                     "has_schema": true,
                     "doc_files": [
                         "docs/output.md",
-                        "docs/usage.md"
+                        "docs/usage.md",
+                        "docs/usage/variantcalling/introduction.md",
+                        "docs/usage/variantcalling/theory.md",
+                        "docs/usage/variantcalling/sarek.md",
+                        "docs/usage/variantcalling/interpretation.md"
                     ],
                     "components": {
                         "modules": [


### PR DESCRIPTION
In order to display correctly a nested structure in the usage page for Sarek, we modify the `pipelines.json` as

```
"doc_files": [
                        "docs/output.md",
                        "docs/usage.md",
                        "docs/usage/variantcalling/introduction.md",
                        "docs/usage/variantcalling/theory.md",
                        "docs/usage/variantcalling/sarek.md",
                        "docs/usage/variantcalling/interpretation.md"
                    ],
```

this will add one subfolder to /usage and the tutorial pages under the topic, thus allowing additional tutorials for different topics to be added in the near future.