### PR TITLE
Use single nextflow.config for nf-test subworkflows

### DIFF
--- a/sites/docs/src/content/docs/guidelines/components/modules.md
+++ b/sites/docs/src/content/docs/guidelines/components/modules.md
@@ -782,6 +782,10 @@ process {
 
 No other settings should go into this file.
 
+:::tip
+Supply the config only to the tests that use `params`, otherwise define `params` for every test including the stub test.
+:::
+
 ## Misc
 
 ### General module code formatting

--- a/sites/docs/src/content/docs/guidelines/components/subworkflows.md
+++ b/sites/docs/src/content/docs/guidelines/components/subworkflows.md
@@ -171,6 +171,46 @@ Input data SHOULD be referenced with the `modules_testdata_base_path` parameter:
 file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true)
 ```
 
+### Configuration
+
+Subworkflow nf-tests SHOULD use a single `nextflow.config` to supply `ext.args` to a subworkflow. They can be defined in the `when` block of a test under the `params` scope.
+
+```groovy {4-7} title="main.nf.test"
+config './nextflow.config'
+
+when {
+  params {
+    moduleA_args = '--extra_opt1 --extra_opt2'
+    moduleB_args = '--extra_optX'
+  }
+  process {
+    """
+    input[0] = [
+      [ id:'test1', single_end:false ], // meta map
+      file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true)
+    ]
+    """
+  }
+}
+```
+
+```groovy {3,6} title="nextflow.config"
+process {
+  withName: 'MODULEA' {
+    ext.args = params.moduleA_args
+  }
+  withName: 'MODULEB' {
+    ext.args = params.moduleB_args
+  }
+}
+```
+
+No other settings should go into this file.
+
+:::tip
+Supply the config only to the tests that use `params`, otherwise define `params` for every test including the stub test.
+:::
+
 ## Misc
 
 ### General module code formatting


### PR DESCRIPTION
Add use of single nextflow.config for nf-test subworkflows too. 

@netlify /docs/guidelines/components/modules