### PR TITLE
Update prettier dependancies with Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,8 +15,10 @@
             customType: 'regex',
             fileMatch: ['^\\.pre-commit-config\\.yaml$'],
             matchStrings: [
-                '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VER(SION)?\\s*:\\s*["\']?(?<currentValue>.+?)["\']?\\s',
+                '- (?<depName>[^@]+)@(?<currentValue>[^\\s]+)'
             ],
-        },
+            datasourceTemplate: 'npm',
+            versioningTemplate: 'semver'
+        }
     ],
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: 'v3.1.0'
     hooks:
       - id: prettier
+        # NOTE https://github.com/pre-commit/pre-commit/issues/3133
         additional_dependencies:
           - prettier@3.2.5
           - prettier-plugin-svelte@^3.1.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,6 @@ repos:
     hooks:
       - id: prettier
         additional_dependencies:
-          # renovate: datasource=npm depName=prettier versioning=semver
           - prettier@3.2.5
           - prettier-plugin-svelte@^3.1.2
           - prettier-plugin-astro@^0.12.3


### PR DESCRIPTION
This picks the dependacies up locally for me with `renovate --platform=local`!

Used this example: https://docs.renovatebot.com/presets-customManagers/#custommanagersbiomeversions
A couple of examples from the 
`renovate: datasource=npm depName=prettier versioning=semver` syntax search
https://github.com/mrzzy/warp/blob/main/renovate.json#L24-L31
https://github.com/leonyork/xk6-output-timestream/blob/main/renovate.json
