### PR TITLE
Move coordinates of NGI slightly, so it does not overlap with NBIS.

### DIFF
--- a/sites/main-site/src/config/contributors.yaml
+++ b/sites/main-site/src/config/contributors.yaml
@@ -343,7 +343,7 @@ contributors:
     contact: Mahesh Binzer-Panchal
     contact_email: mahesh.panchal@nbis.se
     contact_github: mahesh-panchal
-    location: [59.3505174, 18.0221508]
+    location: [59.841993, 17.636388]
     twitter: NBISwe
 
   - full_name: Institut Curie

--- a/sites/main-site/src/config/contributors.yaml
+++ b/sites/main-site/src/config/contributors.yaml
@@ -20,7 +20,7 @@ contributors:
     contact: Franziska Bonath
     contact_email: franziska.bonath@scilifelab.se
     contact_github: FranBonath
-    location: [59.3505174, 18.0221508]
+    location: [59.3505264, 18.0229128]
     twitter: ngisweden
 
   - full_name: Quantitative Biology Center


### PR DESCRIPTION
An institution does not get rendered in the contributor's map, if the coordinates are identical with another. Therefore, slightly move the NGI pin to the actual office location of NGI Stockholm from the garden it used to share with NBIS. 

NBIS pointer was moved to BMC Uppsala, since this is the official postal address.