### PR TITLE
Adding references-assets to ignored_repos.yaml

### DIFF
--- a/sites/main-site/src/config/ignored_repos.yaml
+++ b/sites/main-site/src/config/ignored_repos.yaml
@@ -18,6 +18,7 @@ ignore_repos:
   - ops
   - prettier-plugin-nextflow
   - references
+  - references-assets
   - setup-nextflow
   - setup-nf-test
   - stats


### PR DESCRIPTION
I want to store https://github.com/nf-core/references/tree/dev/assets outside of the #references repo, because it's data that is disconnected to the pipeline I could then update one without updating the other