### PR TITLE
event: add hackathon site registration form

### DIFF
--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/index.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/index.mdx
@@ -8,7 +8,7 @@ endDate: '2025-03-26'
 endTime: '17:00+02:00'
 locations:
     - name: Gather town, Slack, and local sites.
-# importTypeform: true
+importTypeform: true
 announcement:
     text: 'Registration for the online / distributed March hackathon is now open!'
     start: 2025-02-22T00:00:00+01:00
@@ -19,7 +19,35 @@ announcement:
 
 Join us online and in person **March 24-26, 2025**, for the nf-core hackathon! 🗓️
 
-We will be doing an online + distributed hackathon, as held in [2023](/events/2023/hackathon-march-2023) and [2024](/events/2024/hackathon-march-2024).
+You can join for free from wherever you are online, or travel to a local site
+to hack with other Nextflow / nf-core enthusiasts in person!
 
-Currently we are [accepting registrations](https://seqera.typeform.com/hackathon-sites) from organizers interested in hosting local hackathon sites.
-You will be able to find the list of local sites and register as a participant in mid-to-late January. 
+:::info{title="Key dates"}
+
+-   Late December 2024: Registration opens for hosting local sites
+-   Mid-late January 2025: Event registration opens for participation
+-   March 24-26 2025: Hackathon
+
+:::
+
+To get a feel for how the event will work, check out the similar style hackathons
+that we held in [2023](/events/2023/hackathon-march-2023) (16 local sites, 407 attendees)
+and [2024](/events/2024/hackathon-march-2024) (23 local sites, 466 attendees).
+
+## Host a local site
+
+We are now [accepting registrations](https://seqera.typeform.com/hackathon-sites) from
+organizers interested in hosting local hackathon sites :tada:
+
+Anyone is welcome to host a site: you don't need to be an expert or have prior experience with hackathons.
+All you need is enthusiasm and access to a dedicated space for the duration of the event.
+Any space will do: be it a meeting room for 5-10 people through to larger spaces to accommodate more.
+
+If you have any questions, jump into the [`#hackathon-mar-2025`](https://nfcore.slack.com/archives/C081XQ6T3M4)
+channel on the [nf-core Slack](https://nf-co.re/join#slack) and we'll be happy to help.
+
+<div data-tf-live="01JFCDDYQRKKDWFVYDDZ6JQ54W" style="width:100%;height:700px;color:#FFFFFF;"></div>
+
+## Registration
+
+You will be able to find the list of local sites and register to join as a participant in mid-to-late January.

--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/index.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/index.mdx
@@ -19,6 +19,7 @@ announcement:
 
 Join us online and in person **March 24-26, 2025**, for the nf-core hackathon! 🗓️
 
-The plan is to do an online + distributed hackathon, as held in [2023](/events/2023/hackathon-march-2023) and [2024](/events/2024/hackathon-march-2024).
+We will be doing an online + distributed hackathon, as held in [2023](/events/2023/hackathon-march-2023) and [2024](/events/2024/hackathon-march-2024).
 
-For now this is just a placeholder to save the date. Check back soon for more details!
+Currently we are [accepting registrations](https://seqera.typeform.com/hackathon-sites) from organizers interested in hosting local hackathon sites.
+You will be able to find the list of local sites and register as a participant in mid-to-late January. 

--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/index.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/index.mdx
@@ -43,10 +43,10 @@ Anyone is welcome to host a site: you don't need to be an expert or have prior e
 All you need is enthusiasm and access to a dedicated space for the duration of the event.
 Any space will do: be it a meeting room for 5-10 people through to larger spaces to accommodate more.
 
-If you have any questions, jump into the [`#hackathon-mar-2025`](https://nfcore.slack.com/archives/C081XQ6T3M4)
-channel on the [nf-core Slack](https://nf-co.re/join#slack) and we'll be happy to help.
+If you have any questions, jump into the [`#hackathon-mar-2025` channel](https://nfcore.slack.com/archives/C081XQ6T3M4)
+on the [nf-core Slack](https://nf-co.re/join#slack) and we'll be happy to help.
 
-<div data-tf-live="01JFCDDYQRKKDWFVYDDZ6JQ54W" style="width:100%;height:700px;color:#FFFFFF;"></div>
+<div data-tf-live="01JFCDDYQRKKDWFVYDDZ6JQ54W" style="margin-bottom:2rem;"></div>
 
 ## Registration
 


### PR DESCRIPTION
Adds information about the distributed hackathon for organizers including the site registration link.

@netlify /events/2025/hackathon-march-2025