### PR TITLE
No core team personal forwarders any more

### DIFF
--- a/sites/docs/src/content/docs/checklists/community_governance/core_team.mdx
+++ b/sites/docs/src/content/docs/checklists/community_governance/core_team.mdx
@@ -119,8 +119,7 @@ This documents the steps that need to be performed when adding a new core team m
 9. [ ] Add to nf-core google calendar(s)
 10. [ ] Add to `core@nf-co.re` forwarder
 11. [ ] Add to [Zenodo community](https://zenodo.org/communities/nf-core/records?q=&l=list&p=1&s=10) as admin
-12. [ ] Create personal `@nf-co.re` email
-13. [ ] Update Website / About (get new member to check)
-14. [ ] Ask new member to add nf-core apple core emoji as Status
-15. [ ] Make Slack announcement
-16. [ ] Make Social media announcement
+12. [ ] Update Website / About (get new member to check)
+13. [ ] Ask new member to add nf-core apple core emoji as Status
+14. [ ] Make Slack announcement
+15. [ ] Make Social media announcement


### PR DESCRIPTION


@netlify /docs/checklists/community_governance/core_team