### PR TITLE
Update information about Uppsala local site for hackathon March 2025

### DIFF
--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/uppsala-university.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/uppsala-university.mdx
@@ -17,8 +17,22 @@ locations:
 layout: '@layouts/events/HackathonMarch2025.astro'
 ---
 
-Attendees from outside Uppsala University **cannot** attend.
+Attendees from outside Uppsala University **can** attend.
 
-Main contact: Matilda Åslin ([matilda.aslin@medsci.uu.se](mailto:matilda.aslin@medsci.uu.se))
+Organizers:
 
-Venue not yet booked, please check back later for more information.
+- [<i class="fab fa-slack"></i> Matilda Åslin](https://nfcore.slack.com/team/UN7VCPD35) ([matilda.aslin@medsci.uu.se](mailto:matilda.aslin@medsci.uu.se))
+- [<i class="fab fa-slack"></i> Adrien Coulier](https://nfcore.slack.com/team/U044S8RL7K7)
+
+## Venue
+
+For anyone with access, this room is booked for the event: [E10:3303](https://link.mazemap.com/IrrlLmuc)
+
+## Access
+
+:::warning
+If you do not already have access to Navet (main buidling of SciLifeLab Uppsala), you will not be able to access the room without assistance. Please be at entrace C11 before **9 am**, or, if that is not possible, inform one of the organizers on Slack at what time you will arrive, and they will pick you up.
+:::
+
+
+More info to come! Please check back later for more information.


### PR DESCRIPTION
Updated some information about the local site in Uppsala for the Hackathon in March 2025.

@netlify /events/2025/hackathon-march-2025/uppsala-university