### PR TITLE
Leaflet map: style updates

### DIFF
--- a/sites/main-site/src/components/Leaflet.svelte
+++ b/sites/main-site/src/components/Leaflet.svelte
@@ -68,7 +68,6 @@
 <style lang="scss">
     .map {
         height: 480px;
-        width: 90%;
     }
     @media (max-width: 767.98px) {
         // md-breakpoint

--- a/sites/main-site/src/components/Leaflet.svelte
+++ b/sites/main-site/src/components/Leaflet.svelte
@@ -13,8 +13,6 @@
     function createMap(container) {
     m = map(container, {
         minZoom: 1.4,
-        maxBounds: [[-90, -180], [90, 180]],
-        maxBoundsViscosity: 1.0
     }).setView([20, 25.09], 1.4);  // Adjusted center point and zoom
 
         let greenIcon = new Icon({

--- a/sites/main-site/src/components/Leaflet.svelte
+++ b/sites/main-site/src/components/Leaflet.svelte
@@ -11,9 +11,9 @@
 
     let m;
     function createMap(container) {
-    m = map(container, {
-        minZoom: 1.4,
-    }).setView([20, 25.09], 1.4);  // Adjusted center point and zoom
+        m = map(container, {
+            minZoom: 1.4,
+        }).setView([20, 25.09], 1.4); // Adjusted center point and zoom
 
         let greenIcon = new Icon({
             iconUrl: '/images/marker-icon-2x-green.png',

--- a/sites/main-site/src/components/Leaflet.svelte
+++ b/sites/main-site/src/components/Leaflet.svelte
@@ -67,7 +67,7 @@
 
 <style lang="scss">
     .map {
-        height: 480px;
+        height: 500px;
     }
     @media (max-width: 767.98px) {
         // md-breakpoint

--- a/sites/main-site/src/components/Leaflet.svelte
+++ b/sites/main-site/src/components/Leaflet.svelte
@@ -11,7 +11,12 @@
 
     let m;
     function createMap(container) {
-        m = map(container, { minZoom: 2 }).setView([15.505, 10.09], 2);
+    m = map(container, {
+        minZoom: 1.4,
+        maxBounds: [[-90, -180], [90, 180]],
+        maxBoundsViscosity: 1.0
+    }).setView([20, 25.09], 1.4);  // Adjusted center point and zoom
+
         let greenIcon = new Icon({
             iconUrl: '/images/marker-icon-2x-green.png',
             shadowUrl: '/images/marker-shadow.png',
@@ -67,7 +72,8 @@
 
 <style lang="scss">
     .map {
-        height: 500px;
+        height: 400px;
+        width: 90%;
     }
     @media (max-width: 767.98px) {
         // md-breakpoint

--- a/sites/main-site/src/components/event/EventMap.astro
+++ b/sites/main-site/src/components/event/EventMap.astro
@@ -27,6 +27,6 @@ let local_sites_map: {
 local_sites_map = local_sites_map.filter((site) => site !== null);
 ---
 
-<div>
+<div class="mb-5">
     <Leaflet locations={local_sites_map} client:only="svelte" />
 </div>


### PR DESCRIPTION
* 100% width instead of 90% on Leaflet component
* `mt-5` on `div` for EventMap component

Would like to doublecheck centre point and zoom level too, make sure we're not cutting folks off. Though I seem to remember that it's difficult to get a good balance.

@netlify /events/2025/hackathon-march-2025