### PR TITLE
Reorder meetings table in #animal-genomics and fix typos

### DIFF
--- a/sites/main-site/src/content/special-interest-groups/animal-genomics/index.md
+++ b/sites/main-site/src/content/special-interest-groups/animal-genomics/index.md
@@ -41,6 +41,6 @@ The discussion will often be a follow-up on the talk.
 
 Join the [nf-core Slack](/join#slack) and find us in the _#animal-genomics_ channel
 
-# Alumni:
+# Alumni
 
-- bjlang: Björn Langer
+- Björn Langer

--- a/sites/main-site/src/content/special-interest-groups/animal-genomics/meetings.md
+++ b/sites/main-site/src/content/special-interest-groups/animal-genomics/meetings.md
@@ -11,16 +11,16 @@ of every month, usually at 4 PM CET / 10 AM ET / 7 AM PT for 1h.
 
 |               Date | Speaker                                                                                                                      | Event                                                        |
 | -----------------: | :--------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-|             Apr 17 | Christa Kühn (BovReg; Friedrich Loeffler Institute, Germany)                                                                 | [Inauguration](/events/2024/SIG_animalgenomics_inauguration) |
-|             May 15 | Alessandro Bagnato (Department of Veterinary Medicine, University of Milan, Italy)                                           | [May Meeting](/events/2024/SIG_animalgenomics_May)           |
-|             Jun 19 | Yuliaxis Ramayo-Caldas (HoloRuminant; Institute of Agrifood Research and Technology (IRTA), Spain)                           | [June Meeting](/events/2024/SIG_animalgenomics_June)         |
-|             Jul 17 | Cristina Casto Rebollo (Institute for Animal Science and Technology (ICTA), Universitat Politècnica de València, Spain)      | [July Meeting](/events/2024/SIG_animalgenomics_July)         |
-|             Sep 18 | Guillaume Devailly (INRAE, France) with Cervin Guyomar (INRAE, France) and Sandrine Lagarrigue (Institut Agro-INRAE, France) | [September Meeting](/events/2024/SIG_animalgenomics_Sept)    |
-|             Oct 16 | Roderic Guigó Serra (CRG, Spain)                                                                                             | [October Meeting](/events/2024/SIG_animalgenomics_Oct)       |
-| Nov 20 (cancelled) | ~~Harris Lewin (Arizona State University, USA)~~                                                                             | [November Meeting](/events/2024/SIG_animalgenomics_Nov)      |
-|             Dec 18 | Emily Clark (The Roslin Institute, University of Edinburgh, UK)                                                              | [December Meeting](/events/2024/SIG_animalgenomics_Dec)      |
-|             Jan 22 | Round table for discussing the section of the ELIXIR Domestic Animals Genome & Phenome Focus Group                           | [January Meeting](/events/2025/SIG_animalgenomics_Jan)       |
 |             Feb 19 | Harris Lewin (Arizona State University, USA)                                                                                 | TBA                                                          |
+|             Jan 22 | Round table for discussing the section of the ELIXIR Domestic Animals Genome & Phenome Focus Group                           | [January Meeting](/events/2025/SIG_animalgenomics_Jan)       |
+|             Dec 18 | Emily Clark (The Roslin Institute, University of Edinburgh, UK)                                                              | [December Meeting](/events/2024/SIG_animalgenomics_Dec)      |
+| Nov 20 (cancelled) | ~~Harris Lewin (Arizona State University, USA)~~                                                                             | [November Meeting](/events/2024/SIG_animalgenomics_Nov)      |
+|             Oct 16 | Roderic Guigó Serra (CRG, Spain)                                                                                             | [October Meeting](/events/2024/SIG_animalgenomics_Oct)       |
+|             Sep 18 | Guillaume Devailly (INRAE, France) with Cervin Guyomar (INRAE, France) and Sandrine Lagarrigue (Institut Agro-INRAE, France) | [September Meeting](/events/2024/SIG_animalgenomics_Sept)    |
+|             Jul 17 | Cristina Casto Rebollo (Institute for Animal Science and Technology (ICTA), Universitat Politècnica de València, Spain)      | [July Meeting](/events/2024/SIG_animalgenomics_July)         |
+|             Jun 19 | Yuliaxis Ramayo-Caldas (HoloRuminant; Institute of Agrifood Research and Technology (IRTA), Spain)                           | [June Meeting](/events/2024/SIG_animalgenomics_June)         |
+|             May 15 | Alessandro Bagnato (Department of Veterinary Medicine, University of Milan, Italy)                                           | [May Meeting](/events/2024/SIG_animalgenomics_May)           |
+|             Apr 17 | Christa Kühn (BovReg; Friedrich Loeffler Institute, Germany)                                                                 | [Inauguration](/events/2024/SIG_animalgenomics_inauguration) |
 
 # How to join
 


### PR DESCRIPTION
The table is now showing newest meeting at the top.