### PR TITLE
Add information about hackathon 2025 local site Montreal.

### DIFF
--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/index.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/index.mdx
@@ -69,6 +69,7 @@ For the most recent information about your site as well as the contact details o
 | 🇧🇪 Belgium        | Ghent       | Ghent University                               | [Read more](/events/2025/hackathon-march-2025/ghent-university)                                    |
 | 🇧🇷 Brazil         | Natal       | Federal University of Rio Grande do Norte      | [Read more](/events/2025/hackathon-march-2025/university-of-rio-grande-do-norte)                   |
 | 🇧🇷 Brazil         | Guarapuava  | Federal Technological University of Paraná     | [Read more](/events/2025/hackathon-march-2025/utfpr_brazil)                                        |
+| 🇨🇦 Canada         | Montreal    | McGill University offices                      | [Read more](/events/2025/hackathon-march-2025/montreal-mcgill)                                    |
 | 🇨🇿 Czech Republic | Brno        | CEITEC MU                                      | [Read more](/events/2025/hackathon-march-2025/ceitec-mu)                                           |
 | 🇨🇴 Colombia       | Bogota      | University of the Andes                        | [Read more](/events/2025/hackathon-march-2025/bogota-colombia)                                     |
 | 🇪🇹 Ethiopia       | Addis Ababa | Nexsis Analytics                               | [Read more](/events/2025/hackathon-march-2025/nexsis-addis-ethiopia)                               |

--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/index.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/index.mdx
@@ -69,7 +69,7 @@ For the most recent information about your site as well as the contact details o
 | 🇧🇪 Belgium        | Ghent       | Ghent University                               | [Read more](/events/2025/hackathon-march-2025/ghent-university)                                    |
 | 🇧🇷 Brazil         | Natal       | Federal University of Rio Grande do Norte      | [Read more](/events/2025/hackathon-march-2025/university-of-rio-grande-do-norte)                   |
 | 🇧🇷 Brazil         | Guarapuava  | Federal Technological University of Paraná     | [Read more](/events/2025/hackathon-march-2025/utfpr_brazil)                                        |
-| 🇨🇦 Canada         | Montreal    | McGill University offices                      | [Read more](/events/2025/hackathon-march-2025/montreal-mcgill)                                    |
+| 🇨🇦 Canada         | Montreal    | McGill University offices                      | [Read more](/events/2025/hackathon-march-2025/montreal-mcgill)                                     |
 | 🇨🇿 Czech Republic | Brno        | CEITEC MU                                      | [Read more](/events/2025/hackathon-march-2025/ceitec-mu)                                           |
 | 🇨🇴 Colombia       | Bogota      | University of the Andes                        | [Read more](/events/2025/hackathon-march-2025/bogota-colombia)                                     |
 | 🇪🇹 Ethiopia       | Addis Ababa | Nexsis Analytics                               | [Read more](/events/2025/hackathon-march-2025/nexsis-addis-ethiopia)                               |

--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/montreal-mcgill.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/montreal-mcgill.mdx
@@ -24,5 +24,6 @@ Main contact: Florian Wuennemann ([flowuenne@gmail.com](mailto:flowuenne@gmail.c
 
 # Participation
 
-Anybody who is interested **can** attend. Please make sure to select the local site during registration and please contact Florian Wuennemann prior to the event since we are limited to approximately
+Anybody who is interested **can** attend. 
+Please make sure to select the local site during registration and please contact Florian Wuennemann prior to the event since we are limited to approximately
 15 people.

--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/montreal-mcgill.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/montreal-mcgill.mdx
@@ -1,0 +1,28 @@
+---
+title: 'Hackathon - March 2025 (Montreal McGill)'
+subtitle: 'Local node of the nf-core hackathon in Montreal at McGill offices'
+shortTitle: '🇨🇦 Montreal McGill'
+type: 'hackathon'
+startDate: '2025-03-24'
+startTime: '09:00+01:00'
+endDate: '2025-03-26'
+endTime: '17:00+01:00'
+locations:
+    - name: Montreal McGill offices
+      address: |
+          Lovelace Conference Room, Suite 1800, 1010 Rue Sherbrooke Ouest, Montreal, QC H3A 2R7
+      links:
+          - https://www.mcgill.ca/facilities/downtown-campus
+      geoCoordinates: [45.502250, -73.575490]
+layout: '@layouts/events/HackathonMarch2025.astro'
+---
+
+# Contacts
+
+Main contact: Florian Wuennemann ([flowuenne@gmail.com](mailto:flowuenne@gmail.com))
+[<i class="fab fa-slack"></i> Florian Wuennemann](https://nfcore.slack.com/team/UU10KMQ1F) ([flowuenne@gmail.com](mailto:flowuenne@gmail.com))
+
+# Participation
+
+Anybody who is interested **can** attend. Please make sure to select the local site during registration and please contact Florian Wuennemann prior to the event since we are limited to approximately
+15 people.

--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/montreal-mcgill.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/montreal-mcgill.mdx
@@ -24,6 +24,6 @@ Main contact: Florian Wuennemann ([flowuenne@gmail.com](mailto:flowuenne@gmail.c
 
 # Participation
 
-Anybody who is interested **can** attend. 
+Anybody who is interested **can** attend.
 Please make sure to select the local site during registration and please contact Florian Wuennemann prior to the event since we are limited to approximately
 15 people.

--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/montreal-mcgill.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/montreal-mcgill.mdx
@@ -20,7 +20,7 @@ layout: '@layouts/events/HackathonMarch2025.astro'
 # Contacts
 
 Main contact: Florian Wuennemann ([flowuenne@gmail.com](mailto:flowuenne@gmail.com))
-[<i class="fab fa-slack"></i> Florian Wuennemann](https://nfcore.slack.com/team/UU10KMQ1F) ([flowuenne@gmail.com](mailto:flowuenne@gmail.com))
+[<i class="fab fa-slack"></i> Florian Wuennemann](https://nfcore.slack.com/team/UU10KMQ1F)
 
 # Participation
 


### PR DESCRIPTION
Added initial information for the local site in Montreal.

@netlify /events/2025/hackathon-march-2025/montreal-mcgill