### PR TITLE
Hackathon: Count local sites

### DIFF
--- a/sites/main-site/src/components/event/EventLocationsTable.astro
+++ b/sites/main-site/src/components/event/EventLocationsTable.astro
@@ -4,6 +4,7 @@ import { getCollection } from 'astro:content';
 
 interface Props {
     eventPath: string;
+    showCount: boolean;
 }
 
 // Map of country names to their flag emoji for easier lookup
@@ -35,7 +36,7 @@ const COUNTRIES = {
     USA: '🇺🇸',
 } as const;
 
-const { eventPath } = Astro.props;
+const { eventPath, showCount = false } = Astro.props;
 
 // Get location pages for the current event
 const locationPages = (await getCollection('events'))
@@ -56,7 +57,18 @@ const locationPages = (await getCollection('events'))
         };
     })
     .sort((a, b) => (a.countryInfo?.name ?? '').localeCompare(b.countryInfo?.name ?? ''));
+
+const locationCount = locationPages.length;
+const countryCount = new Set(locationPages.map((page) => page.countryInfo?.name).filter(Boolean)).size;
 ---
+
+{
+    showCount && (
+        <p>
+            There are currently {locationCount} local sites in {countryCount} countries!
+        </p>
+    )
+}
 
 <div class="table-responsive">
     <table class="table table-hover table-sm small">

--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/index.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/index.mdx
@@ -63,7 +63,7 @@ For the most recent information about your site as well as the contact details o
 
 <EventMap event={'2025/hackathon-march-2025'} />
 
-<EventLocationsTable eventPath="2025/hackathon-march-2025" />
+<EventLocationsTable eventPath="2025/hackathon-march-2025" showCount={true} />
 
 ## Host a local site
 


### PR DESCRIPTION
Because I'm lazy and now these events are getting bigger, counting this manually is getting hard work!

> There are currently 36 local sites in 25 countries!

@netlify /events/2025/hackathon-march-2025