### PR TITLE
Add argentina to countries map

### DIFF
--- a/sites/main-site/src/components/event/EventLocationsTable.astro
+++ b/sites/main-site/src/components/event/EventLocationsTable.astro
@@ -9,6 +9,7 @@ interface Props {
 
 // Map of country names to their flag emoji for easier lookup
 const COUNTRIES = {
+    Argentina: '🇦🇷',
     Australia: '🇦🇺',
     Belgium: '🇧🇪',
     Brazil: '🇧🇷',


### PR DESCRIPTION
Argentina initials don't render in Hackathon [main page](https://nf-co.re/events/2025/hackathon-march-2025):
![image](https://github.com/user-attachments/assets/896fda3b-2540-475d-8249-d1151d6acf13)

Not sure if this is the only reason why it isn't rendering, but I'm not sure how to test these changes to verify that it fixes the error. @mashehu since you authored the PR that introduced the automated table generation, could you verify if there is anything else needed? I'm happy to implement any further changes
