### PR TITLE
Hackathon March 2025 - Add Sherbrooke, Canada local site

### DIFF
--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/scil-sherbrooke.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/scil-sherbrooke.mdx
@@ -4,9 +4,9 @@ subtitle: "Local node of the nf-core hackathon in Sherbrooke, Quebec, Canada"
 shortTitle: "🇨🇦 Sherbrooke Quebec Canada"
 type: "hackathon"
 startDate: "2025-03-25"
-startTime: "09:00+01:00"
+startTime: "09:00-05:00"
 endDate: "2025-03-25"
-endTime: "17:00+01:00"
+endTime: "17:00-05:00"
 locations:
     - name: Université de Sherbrooke
       address: |

--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/scil-sherbrooke.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/scil-sherbrooke.mdx
@@ -1,0 +1,31 @@
+---
+title: "Hackathon - March 2025 (SCIL - Université de Sherbrooke)"
+subtitle: "Local node of the nf-core hackathon in Sherbrooke, Quebec, Canada"
+shortTitle: "🇨🇦 Sherbrooke Quebec Canada"
+type: "hackathon"
+startDate: "2025-03-25"
+startTime: "09:00+01:00"
+endDate: "2025-03-25"
+endTime: "17:00+01:00"
+locations:
+    - name: Université de Sherbrooke
+      address: |
+          Campus Principal, 2500 Boulevard de l'Université, Sherbrooke, QC J1K 2R1, Canada
+      links:
+          - https://scil.usherbrooke.ca/
+          - https://www.usherbrooke.ca/
+      geoCoordinates: [45.379917, 71.925806]
+      country: Canada
+      city: Sherbrooke
+layout: "@layouts/events/HackathonMarch2025.astro"
+---
+
+Attendees from outside the SCIL and Université de Sherbrooke **are welcome**. However, due to
+the small space and limited resources, attendance is restricted to invited participants only.
+Please, contact the organizers for more information.
+
+Organizers:
+
+-   [SCIL](https://scil.usherbrooke.ca/)-[Université de Sherbrooke](https://usherbrooke.ca/)
+-   [<i class="fab fa-slack"></i> Alex Valcourt Caron](https://nfcore.slack.com/team/U06DEAUN85D)
+-   [<i class="fab fa-slack"></i> Arnaud Boré](https://nfcore.slack.com/team/U0749LM7406)


### PR DESCRIPTION
Title says it all. I haven't found how to add myself to the table (haven't found the table in fact), but looking at other PRs, I see only this file submitted.

@netlify /events/2025/hackathon-march-2025/scil-sherbrooke