### PR TITLE
Fix Madrid ISCIII local site information and rename `mdx` file

### DIFF
--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/isciii-madrid-spain.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/isciii-madrid-spain.mdx
@@ -1,19 +1,19 @@
 ---
-title: "Hackathon - March 2025 (National Centre of Microbiology, Spain)"
-subtitle: "Local node of the nf-core hackathon at the National Centre of Microbiology (ISCIII), Spain"
-shortTitle: "🇪🇸 National Centre of Microbiology (ISCIII) - Madrid"
+title: "Hackathon - March 2025 ISCIII (Madrid, Spain)"
+subtitle: "Local node of the nf-core hackathon at the  BU-ISCIII / CIBERINFEC-BIPLAT, Spain"
+shortTitle: "🇪🇸  ISCIII - CIBERINFEC (Madrid)"
 type: "hackathon"
 startDate: "2025-03-24"
 startTime: "09:00+01:00"
 endDate: "2025-03-26"
 endTime: "17:00+01:00"
 locations:
-    - name: "National Centre of Microbiology (ISCIII)"
+    - name: "Majadahonda Campus"
       address: |
-          Building 53 (National Centre of Microbiology), Rooms 24-25-26
+          Building 53, Room 2
           St. Pozuelo, 28, 28222 Majadahonda, Madrid, Spain
       links: [https://www.isciii.es/en/]
-      geoCoordinates: [40.4750, -3.6905]
+      geoCoordinates: [40.4592778, -3.86475]
       country: Spain
       city: Madrid
 layout: "@layouts/events/HackathonMarch2025.astro"


### PR DESCRIPTION
We had to fix information in `mdx` file for Madrid local site and rename file.

@netlify /events/2025/hackathon-march-2025/isciii-madrid-spain.mdx

(Registration form: @mribeirodantas @kenibrewer @christopher-hakkaart)

(Old version in: #3045 )