### PR TITLE
Hosting local site for March 2025 Hackathon

### DIFF
--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/certh.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/certh.mdx
@@ -14,6 +14,8 @@ locations:
       links:
           - https://www.certh.gr/root.en.aspx
       geoCoordinates: [40.566694, 22.997605]
+      country: Greece
+      city: Thessaloniki
 layout: '@layouts/events/HackathonMarch2025.astro'
 ---
 

--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/certh.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/certh.mdx
@@ -26,4 +26,7 @@ Main contact: [<i class="fab fa-slack"></i> Nikos Pechlivanis](https://nfcore.sl
 ## Venue
 
 You will find us at the central library of the campus.
-_Note_: March 25th is the Greek Independence Day (national holiday) - the venue will not be available!
+
+:::warning
+March 25th is the Greek Independence Day (national holiday) - the venue will not be available!
+:::

--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/certh.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/certh.mdx
@@ -1,14 +1,14 @@
 ---
 title: 'Hackathon - March 2025 (Centre for Research and Technology, Hellas)'
-subtitle: 'Local node of the nf-core hackathon at Centre for Research and Technology, Greece'
-shortTitle: '🇬🇷 Centre for Research and Technology'
+subtitle: 'Local node of the nf-core hackathon at Centre for Research and Technology, Hellas'
+shortTitle: '🇬🇷 Centre for Research and Technology, Hellas'
 type: 'hackathon'
 startDate: '2025-03-24'
 startTime: '09:00+02:00'
 endDate: '2025-03-26'
 endTime: '17:00+02:00'
 locations:
-    - name: Centre for Research and Technology
+    - name: Centre for Research and Technology, Hellas
       address: |
           6th km Charilaou-Thermi Rd, P.O. Box 60361, GR 57001 Thermi, Thessaloniki, Greece
       links:
@@ -17,7 +17,7 @@ locations:
 layout: '@layouts/events/HackathonMarch2025.astro'
 ---
 
-Attendees from outside the Centre for Research and Technology,  **can** attend.
+Attendees from outside CERTH, **can** attend.
 
 Main contact: [<i class="fab fa-slack"></i> Nikos Pechlivanis](https://nfcore.slack.com/team/U083L3UDXMG) | [nikosp41@certh.gr](mailto:nikosp41@certh.gr)
 

--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/certh.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/certh.mdx
@@ -13,7 +13,7 @@ locations:
           6th km Charilaou-Thermi Rd, P.O. Box 60361, GR 57001 Thermi, Thessaloniki, Greece
       links:
           - https://www.certh.gr/root.en.aspx
-      geoCoordinates: [40.566694, 22.997605]
+      geoCoordinates: [40.56707, 22.99822]
       country: Greece
       city: Thessaloniki
 layout: '@layouts/events/HackathonMarch2025.astro'
@@ -25,4 +25,4 @@ Main contact: [<i class="fab fa-slack"></i> Nikos Pechlivanis](https://nfcore.sl
 
 ## Venue
 You will find us at the central library of the campus.
-_Note_: March 25th is Greek Independence Day, a national holiday. The venue will not be available!
+_Note_: March 25th is the Greek Independence Day (national holiday) - the venue will not be available!

--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/certh.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/certh.mdx
@@ -24,5 +24,6 @@ Attendees from outside CERTH, **can** attend.
 Main contact: [<i class="fab fa-slack"></i> Nikos Pechlivanis](https://nfcore.slack.com/team/U083L3UDXMG) | [nikosp41@certh.gr](mailto:nikosp41@certh.gr)
 
 ## Venue
+
 You will find us at the central library of the campus.
 _Note_: March 25th is the Greek Independence Day (national holiday) - the venue will not be available!

--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/certh.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/certh.mdx
@@ -1,0 +1,25 @@
+---
+title: 'Hackathon - March 2025 (Centre for Research and Technology, Hellas)'
+subtitle: 'Local node of the nf-core hackathon at Centre for Research and Technology, Greece'
+shortTitle: '🇬🇷 Centre for Research and Technology'
+type: 'hackathon'
+startDate: '2025-03-24'
+startTime: '09:00+02:00'
+endDate: '2025-03-26'
+endTime: '17:00+02:00'
+locations:
+    - name: Centre for Research and Technology
+      address: |
+          6th km Charilaou-Thermi Rd, P.O. Box 60361, GR 57001 Thermi, Thessaloniki, Greece
+      links:
+          - https://www.certh.gr/root.en.aspx
+      geoCoordinates: [40.566694, 22.997605]
+layout: '@layouts/events/HackathonMarch2025.astro'
+---
+
+Attendees from outside the Centre for Research and Technology,  **can** attend.
+
+Main contact: [<i class="fab fa-slack"></i> Nikos Pechlivanis](https://nfcore.slack.com/team/U083L3UDXMG) | [nikosp41@certh.gr](mailto:nikosp41@certh.gr)
+
+## Venue
+You will find us at the central library of the campus.

--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/certh.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/certh.mdx
@@ -23,3 +23,4 @@ Main contact: [<i class="fab fa-slack"></i> Nikos Pechlivanis](https://nfcore.sl
 
 ## Venue
 You will find us at the central library of the campus.
+_Note_: March 25th is Greek Independence Day, a national holiday. The venue will not be available!

--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/certh.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/certh.mdx
@@ -1,12 +1,12 @@
 ---
-title: 'Hackathon - March 2025 (Centre for Research and Technology, Hellas)'
-subtitle: 'Local node of the nf-core hackathon at Centre for Research and Technology, Hellas'
-shortTitle: '🇬🇷 Centre for Research and Technology, Hellas'
-type: 'hackathon'
-startDate: '2025-03-24'
-startTime: '09:00+02:00'
-endDate: '2025-03-26'
-endTime: '17:00+02:00'
+title: "Hackathon - March 2025 (Centre for Research and Technology, Hellas)"
+subtitle: "Local node of the nf-core hackathon at Centre for Research and Technology, Hellas"
+shortTitle: "🇬🇷 Centre for Research and Technology, Hellas"
+type: "hackathon"
+startDate: "2025-03-24"
+startTime: "09:00+02:00"
+endDate: "2025-03-26"
+endTime: "17:00+02:00"
 locations:
     - name: Centre for Research and Technology, Hellas
       address: |
@@ -16,7 +16,7 @@ locations:
       geoCoordinates: [40.56707, 22.99822]
       country: Greece
       city: Thessaloniki
-layout: '@layouts/events/HackathonMarch2025.astro'
+layout: "@layouts/events/HackathonMarch2025.astro"
 ---
 
 Attendees from outside CERTH, **can** attend.


### PR DESCRIPTION
CERTH in Thessaloniki, Greece, as a local site for the March 2025 hackathon.

@netlify /events/2025/hackathon-march-2025/certh