### PR TITLE
Update snapshotting-variable-files-in-a-channel-emitting-a-directory

### DIFF
--- a/sites/docs/src/content/docs/contributing/nf-test/assertions.md
+++ b/sites/docs/src/content/docs/contributing/nf-test/assertions.md
@@ -337,12 +337,12 @@ then {
     def stableNames = allFiles.grep { file -> unstableNames.contains(file.name.toString()) }
 
     assertAll(
+        { assert process.success },
         { assert snapshot(
-            stableFiles,
-            stableNames,
-            process.out.versions
-        ).match() },
-        { assert process.success }
+                stableFiles,
+                stableNames,
+                process.out.versions
+            ).match() }
     )
 }
 ```

--- a/sites/docs/src/content/docs/contributing/nf-test/assertions.md
+++ b/sites/docs/src/content/docs/contributing/nf-test/assertions.md
@@ -331,17 +331,18 @@ _Motivation_: I want to snapshot all files with stable md5sums, but only snapsho
 
 ```bash
 then {
-    def stablefiles = []
-    file(process.out.db.get(0).get(1)).eachFileRecurse{ file -> if (!file.isDirectory() && !["database.log", "database.fastaid2LCAtaxid", "database.taxids_with_multiple_offspring"].find {file.toString().endsWith(it)}) {stablefiles.add(file)} }
-    def unstablefiles = []
-    file(process.out.db.get(0).get(1)).eachFileRecurse{ file -> if (["database.log", "database.fastaid2LCAtaxid", "database.taxids_with_multiple_offspring"].find {file.toString().endsWith(it)}) {unstablefiles.add(file.getName().toString())} }
+    def allFiles = file(process.out.db.get(0).get(1)).listFiles().sort()
+    def unstableNames = ["database.log", "database.fastaid2LCAtaxid", "database.taxids_with_multiple_offspring"]
+    def stableFiles = allFiles.grep { file -> ! unstableNames.contains(file.name) }
+    def stableNames = allFiles.grep { file -> unstableNames.contains(file.name.toString()) }
+
     assertAll(
-        { assert process.success },
         { assert snapshot(
-                stablefiles.sort(),
-                unstablefiles.sort(),
-                process.out.versions
-            ).match() }
+            stableFiles,
+            stableNames,
+            process.out.versions
+        ).match() },
+        { assert process.success }
     )
 }
 ```

--- a/sites/docs/src/content/docs/contributing/nf-test/assertions.md
+++ b/sites/docs/src/content/docs/contributing/nf-test/assertions.md
@@ -332,9 +332,12 @@ _Motivation_: I want to snapshot all files with stable md5sums, but only snapsho
 ```bash
 then {
     def allFiles = file(process.out.db.get(0).get(1)).listFiles().sort()
+    // Defile all files that have unstable content (ie: timestamp, non-deterministic or any other variable content)
     def unstableNames = ["database.log", "database.fastaid2LCAtaxid", "database.taxids_with_multiple_offspring"]
-    def stableFiles = allFiles.grep { file -> ! unstableNames.contains(file.name) }
-    def stableNames = allFiles.grep { file -> unstableNames.contains(file.name.toString()) }
+    // Filter out the unstable files
+    def stableFiles = allFiles.grep { file -> !unstableNames.contains(file.name) }
+    // Collect the stable file names
+    def stableNames = allFiles.grep { file -> unstableNames.contains(file.name) }.collect { file -> file.name }
 
     assertAll(
         { assert process.success },


### PR DESCRIPTION
Prove a nicer example for snapshotting stable files and stable names

@netlify /docs/contributing/nf-test/assertions