### PR TITLE
Fix link in docs

### DIFF
--- a/sites/docs/src/content/docs/usage/Getting_started/configuration.md
+++ b/sites/docs/src/content/docs/usage/Getting_started/configuration.md
@@ -350,7 +350,7 @@ Sometimes tool developers change how tool versions are reported between updates.
 
 In some cases you may wish to understand which tool arguments or options a pipeline uses, or even update or change these for your own analyses.
 
-You can sometimes find out what parameters are used in a tool in by checking the longer 'help' description of different pipeline parameters, e.g. by pressing the 'help' button next to [this parameter](https://nf-co.re/funcscan/1.0.1/parameters#annotation_bakta_mincontig) in [nf-core/funcscan](https://nf-co.re/funcscan).
+You can sometimes find out what parameters are used in a tool in by checking the longer 'help' description of different pipeline parameters, e.g. by pressing the 'help' button next to [this parameter](https://nf-co.re/funcscan/2.0.0/parameters#annotation_bakta_mincontiglen) in [nf-core/funcscan](https://nf-co.re/funcscan).
 
 ### Finding already used arguments
 


### PR DESCRIPTION
Mini PR to fix a link (and update to the recent pipeline version) in configuration docs.

@netlify /docs/usage/Getting_started/configuration