### PR TITLE
fix modules-subworkflows search pagination

### DIFF
--- a/sites/main-site/src/components/component/ComponentListing.svelte
+++ b/sites/main-site/src/components/component/ComponentListing.svelte
@@ -82,6 +82,7 @@
     });
     SearchQuery.subscribe(() => {
         filteredComponents = searchFilterSortComponents(components);
+        $currentPage = 1;
         updatePageSize();
     });
     DisplayStyle.subscribe(() => {


### PR DESCRIPTION
# Fix modules search pagination issue

## Overview

Fixes an issue where browsing modules on https://nf-co.re/modules/ sometimes shows blank search results.
This fix simply sets the `currentPage = 1` for the paginator each time the `SearchQuery` is updated.

Closes #2883

Presumably the subworkflows page has the same issue that will be fixed by this, but it has another bug on top of that (#2942) preventing testing which I'll have a look at in another PR

## Steps to reproduce

1. navigate to https://nf-co.re/modules/
2. go to page 2 of the results (or any page for that matter)
3. search something with limited results such as `abs` (which only has 1 result)
4. result is that search results are filtered down and fit on page 1, however user is left on whichever page they were on before
5. confirm this is the case by clicking `previous` button until back on page 1 where you can see the results
