### PR TITLE
Update medellin-colombia.mdx

### DIFF
--- a/sites/main-site/src/content/events/2025/hackathon-march-2025/medellin-colombia.mdx
+++ b/sites/main-site/src/content/events/2025/hackathon-march-2025/medellin-colombia.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Hackathon - March 2025 (Bogota, Colombia)"
+title: "Hackathon - March 2025 (Medellín, Colombia)"
 subtitle: "Local node of the nf-core hackathon at EAFIT University, Colombia"
 shortTitle: "🇨🇴 Medellín, Colombia"
 type: "hackathon"


### PR DESCRIPTION
Small fix:  Replace Bogota for Medellin as correct location

The title of this local venue says "Bogotá, Colombia", but the correct location ,that is also mentioned below, is Medellín, those are two different cities, and may cause confusion. 


@netlify /events/2025/hackathon-march-2025/medellin-colombia