### PR TITLE
Update ignored_repos.yaml

### DIFF
--- a/sites/main-site/src/config/ignored_repos.yaml
+++ b/sites/main-site/src/config/ignored_repos.yaml
@@ -11,7 +11,6 @@ ignore_repos:
   - logos
   - modules
   - modules-template
-  - nf-co.re
   - nf-core.github.io
   - nft-tiff
   - nft-utils


### PR DESCRIPTION
Remove repo that has changed name.
`nf-co.re` has been `website` for a while, I do think we can remove it from this list