### PR TITLE
Fix TUI invocation command in nf-core tools docs

### DIFF
--- a/sites/docs/src/content/docs/nf-core-tools/tui.md
+++ b/sites/docs/src/content/docs/nf-core-tools/tui.md
@@ -10,7 +10,7 @@ weight: 40
   - _TUI:_ Terminal user interface
 
 The `nf-core` command line interface is fairly large, with a lot of commands and options.
-To make it easier to explore and use, run `nf-core tui` to launch a graphical terminal interface.
+To make it easier to explore and use, run `nf-core interface` to launch a graphical terminal interface.
 
 This functionality works using [Textualize/trogon](https://github.com/Textualize/trogon)
 and is based on the underlying CLI implementation that uses [Click](https://click.palletsprojects.com/).


### PR DESCRIPTION
By the way, the "Edit this page" links on most of the pages under nf-core-tools are not working. (I think it thinks they are subpages but are actually sections).

@netlify /docs/nf-core-tools/tui