### PR TITLE
Add print debugging help to nf-test assertions page

### DIFF
--- a/sites/docs/src/content/docs/contributing/nf-test/assertions.md
+++ b/sites/docs/src/content/docs/contributing/nf-test/assertions.md
@@ -94,6 +94,29 @@ The `get(1)` or `[1]` corresponds to the second object of the channel object.
 Most nf-core modules and pipelines typically emit two sub-components of an object: a meta map and the file(s)/directories etc.
 Specifying `get(q)` or `[1]` thus corresponds to the file(s)/directories for recording in a snapshot.
 
+## Debugging
+
+When you assign variables that you inject into the `assertAll`, you can use `println` statements to print these variables during the test for debugging purposes.
+
+The print statements must go within the `then` block, and prior `assertAll`.
+
+```nextflow
+then {
+    def unstable_patterns_auth = [
+        '**/mapped_reads_gc-content_distribution.txt',
+        '**/genome_gc_content_per_window.png',
+        '**/*.{svg,pdf,html}',
+        '*.{svg,pdf,html}',
+        '**/DamageProfiler.log',
+        ]
+
+    println("unstable_patterns_auth: " + unstable_patterns_auth)
+
+    assertAll(
+        { assert snapshot( stable_content_authentication     , stable_name_authentication*.name   ).match("authentication") },
+    ...
+```
+
 ## Additional Reading
 
 - [Updating Snapshots](https://code.askimed.com/nf-test/docs/assertions/snapshots/#updating-snapshots)


### PR DESCRIPTION
As I keep forgetting how to do it

@netlify /docs/contributing/nf-test/assertions