### PR TITLE
Add Team Leads as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
 src/content/docs @nf-core/docs
 src/content/tutorials @nf-core/training @nf-core/outreach
+
+sites/main-site/src/content/about/governance.mdx @ewels @christopher-hakkaart @FranBonath @mribeirodantas @FriederikeHanssen @jfy133 @maxulysse

--- a/sites/main-site/src/content/about/governance.mdx
+++ b/sites/main-site/src/content/about/governance.mdx
@@ -154,6 +154,7 @@ The infrastructure team will have administrator access to repositories.
 <Profile username="mashehu">Matthias Hörtenhuber</Profile>
 <Profile username="julianflesch">Julian Flesch</Profile>
 <Profile username="ningyuxin1999">Yuxin Ning</Profile>
+<Profile username="edmundmiller">Edmund Miller</Profile>
 
 ## Outreach
 


### PR DESCRIPTION
- **feat: Add team leads as goverance codeowners**
- **feat: Add @edmundmiller to infrastructure**
