### PR TITLE
Added nf-core/scnanoseq preprint to publications page

### DIFF
--- a/sites/main-site/src/content/about/publications.mdx
+++ b/sites/main-site/src/content/about/publications.mdx
@@ -376,3 +376,14 @@ nf-core community, James A. Fellows Yates
 [_bioRxiv_ (2023)](https://doi.org/10.1101/2023.10.20.563221)
 doi: [10.1101/2023.10.20.563221](https://doi.org/10.1101/2023.10.20.563221)
 :::
+
+### [nf-core/scnanoseq](https://nf-co.re/scnanoseq)
+
+:::tip{.fa-newspaper title="scnanoseq: an nf-core pipeline for Oxford Nanopore single-cell RNA-sequencing"}
+
+<Altmetric doi="10.1101/2025.04.08.647887" />
+Austyn Trull, nf-core community, Elizabeth A. Worthey, Lara Ianov
+
+[_bioRxiv_ (2025)](https://doi.org/10.1101/2025.04.08.647887)
+doi: [10.1101/2025.04.08.647887](https://doi.org/10.1101/2025.04.08.647887)
+:::

--- a/sites/main-site/src/content/about/publications.mdx
+++ b/sites/main-site/src/content/about/publications.mdx
@@ -365,6 +365,17 @@ Combiz Khozoie, Nurun Fancy, Mahdi M. Marjaneh, Alan E. Murphy, Paul M. Matthews
 doi: [10.1101/2021.08.16.456499](https://doi.org/10.1101/2021.08.16.456499)
 :::
 
+### [nf-core/scnanoseq](https://nf-co.re/scnanoseq)
+
+:::tip{.fa-newspaper title="scnanoseq: an nf-core pipeline for Oxford Nanopore single-cell RNA-sequencing"}
+
+<Altmetric doi="10.1101/2025.04.08.647887" />
+Austyn Trull, nf-core community, Elizabeth A. Worthey, Lara Ianov
+
+[_bioRxiv_ (2025)](https://doi.org/10.1101/2025.04.08.647887)
+doi: [10.1101/2025.04.08.647887](https://doi.org/10.1101/2025.04.08.647887)
+:::
+
 ### [nf-core/taxprofiler](https://nf-co.re/taxprofiler)
 
 :::tip{.fa-newspaper title="nf-core/taxprofiler: Highly parallelised and flexible pipeline for metagenomic taxonomic classification and profiling"}
@@ -375,15 +386,4 @@ nf-core community, James A. Fellows Yates
 
 [_bioRxiv_ (2023)](https://doi.org/10.1101/2023.10.20.563221)
 doi: [10.1101/2023.10.20.563221](https://doi.org/10.1101/2023.10.20.563221)
-:::
-
-### [nf-core/scnanoseq](https://nf-co.re/scnanoseq)
-
-:::tip{.fa-newspaper title="scnanoseq: an nf-core pipeline for Oxford Nanopore single-cell RNA-sequencing"}
-
-<Altmetric doi="10.1101/2025.04.08.647887" />
-Austyn Trull, nf-core community, Elizabeth A. Worthey, Lara Ianov
-
-[_bioRxiv_ (2025)](https://doi.org/10.1101/2025.04.08.647887)
-doi: [10.1101/2025.04.08.647887](https://doi.org/10.1101/2025.04.08.647887)
 :::


### PR DESCRIPTION
This PR adds the [nf-core/scnanoseq preprint](https://www.biorxiv.org/content/10.1101/2025.04.08.647887v1) to the publications's page.

@netlify /about/publications