### PR TITLE
chore: update slack join link

### DIFF
--- a/sites/main-site/public/_redirects
+++ b/sites/main-site/public/_redirects
@@ -1,5 +1,5 @@
 # Slack invite URL
-/join/slack https://join.slack.com/t/nfcore/shared_invite/zt-321sl3113-sJQ7xyK~30Kf810AwKDLDg
+/join/slack https://join.slack.com/t/nfcore/shared_invite/zt-35ghg4yuo-4n9mBiulATNXQCGiQ6MeUw
 
 # Force a 404 header on custom 404 page
 # See https://answers.netlify.com/t/bug-and-workaround-404-page-returns-http-200/21154


### PR DESCRIPTION
Updates the Slack join link with a fresh URL in preparation for the nf-core hackathon.