### PR TITLE
add youtube link to bytesize_nfcore_fastqrepair

### DIFF
--- a/sites/main-site/src/content/events/2025/bytesize_nfcore_fastqrepair.md
+++ b/sites/main-site/src/content/events/2025/bytesize_nfcore_fastqrepair.md
@@ -7,7 +7,7 @@ startTime: "13:00+02:00"
 endDate: "2025-05-13"
 endTime: "13:30+02:00"
 youtubeEmbed: https://youtu.be/Hjb6doI3n6o
-embedAt:fastqrepair
+embedAt: fastqrepair
 locations:
   - name: Online
     links:

--- a/sites/main-site/src/content/events/2025/bytesize_nfcore_fastqrepair.md
+++ b/sites/main-site/src/content/events/2025/bytesize_nfcore_fastqrepair.md
@@ -6,10 +6,12 @@ startDate: "2025-05-13"
 startTime: "13:00+02:00"
 endDate: "2025-05-13"
 endTime: "13:30+02:00"
+youtubeEmbed: https://youtu.be/Hjb6doI3n6o
+embedAt:fastqrepair
 locations:
   - name: Online
     links:
-      - https://kth-se.zoom.us/j/68390542812
+      - https://youtu.be/Hjb6doI3n6o
 ---
 
 This week, [Tommaso Mazza](https://github.com/tm4zza) is going to introduce the nf-core pipeline [nf-core/fastqrepair](https://nf-co.re/fastqrepair/1.0.0/).


### PR DESCRIPTION
@mashehu I tried to connect it directly to the pipeline site as well, not sure if I did it right though. Would appreciate if you could double check!

@netlify /events/2025/bytesize_nfcore_fastqrepair