### PR TITLE
Add general contribution etiquette guide

### DIFF
--- a/sites/docs/src/content/docs/contributing/how_to_contribute_to_nf-core.md
+++ b/sites/docs/src/content/docs/contributing/how_to_contribute_to_nf-core.md
@@ -1,0 +1,97 @@
+---
+title: "How to contribute to nf-core"
+subtitle: "Etiquette guidelines for contributing to nf-core"
+---
+
+Welcome to the nf-core community!
+
+We are looking forward to your contributions.
+If this is your first time, please read the below to orient yourself on how contributing works within our community.
+
+## Code of conduct
+
+The [code of conduct](https://nf-co.re/code_of_conduct) is a core document for ensuring everyone gets along well within our diverse, distributed group. Before you start, take a moment to review this document.
+
+## Communication
+
+Our primary communication platforms is our Slack workspace and the communication features for various GitHub repositories (i.e., Issues and Pull Requests).
+
+Popular repositories include:
+
+- [nf-core/modules](https://github.com/nf-core/modules): Shared Nextflow modules and subworkflows
+- [nf-core/tools](https://github.com/nf-core/tools): nf-core toolkit, including module, subworkflow, and pipeline templates
+- [nf-core/website](https://github.com/nf-core/website): nf-core documentation
+- [nf-core/testdatasets](https://github.com/nf-core/testdatasets): Shared test data files for unit testing
+- [nf-core/configs](https://github.com/nf-core/configs): Shared Nextflow configuration files for HPC and cloud infrastructure
+
+## Joining the Slack and GitHub organisations
+
+To join the Slack workspace, see our [Join nf-core](https://nf-co.re/join) page for instructions.
+
+After joining Slack, we recommend you join our GitHub organisation.
+
+The GitHub organization is open to everyone and offers a range of benefits, including not having to wait for someone to approve CI tests and reviewing and merging rights (on most repositories).
+
+To join the GitHub workspace, see our [Join nf-core](https://nf-co.re/join) page for instructions
+
+:::tip
+You need to join our Slack workspace first 😉
+:::
+
+## Asking for help
+
+If you have questions and don't know where to start, ask in our dedicated Slack help channels:
+
+- [#nostupidquestions](https://nfcore.slack.com/archives/C043FMKUNLB)
+- [#help](https://nfcore.slack.com/archives/CE6SDBX2A).
+
+## Pull requests
+
+Everyone is welcome to open a pull request on our GitHub repositories.
+
+Before opening a pull request, join the GitHub organisation so that any tests will automatically run.
+
+As a general rule, all pull requests must be reviewed by another community member.
+
+It's also good to be patient - like many open source projects, nf-core is driven by volunteers and noone is obliged to review your work. It's typically easier to get reviews for smaller requests than larger, just like PRs in line with the desires of the community are more likely to get a quick review than others.
+
+## Reviewing
+
+Reviews and comments can be technical (code), conceptual (e.g., purpose/background/approach), or both.
+
+Everyone is welcome to review or leave a comment on an nf-core pull request - regardless of whether you are within the nf-core community or not
+You also do not need to be in the nf-core GitHub organisation (although this is recommended).
+
+However, if you review a PR about a 'conceptual' question, a second technical review by another community member is required.
+You can request reviews via the [#request-review](https://nfcore.slack.com/archives/CQY2U5QU9) channel on Slack.
+
+Reviews from community members who are not directly within your development team are recommended.
+
+Be polite and constructive in your comments. Our community has a diverse range of backgrounds, cultures, and expertise.
+
+Help with making a smooth reviewing process by making single reviews with multiple comments, not lots of separate comments (i.e., select **Start review**, not **Add single comment** on the **GitHub Files Changed** tab!)
+
+## Who is who and how to contact them
+
+See the [Governance](https://nf-co.re/governance#governance) page for an overview of the community structure.
+
+As a general rule: always ask the entire community first!
+The answers to the vast majority of questions can be obtained from the entire nf-core hivemind.
+
+If you get stuck on something that needs more expert advice or a decision, there are specific teams that may be able to help:
+
+- Issue with modules, pipelines, or test configs: Ask the maintainers team
+- Questions about nf-core events or the bytesize series: Ask the outreach team
+- Problems with the nf-core template, tooling, GitHub actions, or AWS: Ask the infrastructure team!
+- Critical decision made that may affect the entire community, or need something done that requires passwords: Ask the core team!
+- Inter-personal conflict with another member or member(s) of the community: Ask the safety team!
+
+Members of each team are listed on the [Governance](https://nf-co.re/governance#governance) page.
+
+## How to submit a module or subworkflow
+
+For more information about how to submit a new module, see the [Writing nf-core modules and subworkflows](https://nf-co.re/docs/tutorials/nf-core_components/components) tutorial.
+
+## How to submit a pipeline
+
+For more information about how to submit a new pipeline, see the [Adding a pipeline](https://nf-co.re/docs/tutorials/adding_a_pipeline/overview) tutorial.

--- a/sites/docs/src/content/docs/contributing/how_to_contribute_to_nf-core.md
+++ b/sites/docs/src/content/docs/contributing/how_to_contribute_to_nf-core.md
@@ -14,9 +14,9 @@ The [code of conduct](https://nf-co.re/code_of_conduct) is a core document for e
 
 ## Communication
 
-Our primary communication platforms is our Slack workspace and the communication features for various GitHub repositories (i.e., Issues and Pull Requests).
+Our primary communication platforms is our [Slack workspace](https://nfcore.slack.com/) and the communication features for various GitHub repositories (i.e., Issues and Pull Requests).
 
-Popular repositories include:
+Popular common repositories include:
 
 - [nf-core/modules](https://github.com/nf-core/modules): Shared Nextflow modules and subworkflows
 - [nf-core/tools](https://github.com/nf-core/tools): nf-core toolkit, including module, subworkflow, and pipeline templates
@@ -53,13 +53,16 @@ Before opening a pull request, join the GitHub organisation so that any tests wi
 
 As a general rule, all pull requests must be reviewed by another community member.
 
-It's also good to be patient - like many open source projects, nf-core is driven by volunteers and noone is obliged to review your work. It's typically easier to get reviews for smaller requests than larger, just like PRs in line with the desires of the community are more likely to get a quick review than others.
+It's also good to be patient - like many open source projects, nf-core is driven by volunteers and noone is obliged to review your work.
+
+Smaller pull requests (a few files) are more likely to get speedy reviews than large ones (100s files), just like PRs in line with the desires of the community are more likely to get a quick review than others.
+Keep this in mind when preparing your contributions!
 
 ## Reviewing
 
-Reviews and comments can be technical (code), conceptual (e.g., purpose/background/approach), or both.
+Reviews and comments can be technical (code), conceptual (e.g., purpose/background/approach/domain specific), or both.
 
-Everyone is welcome to review or leave a comment on an nf-core pull request - regardless of whether you are within the nf-core community or not
+Everyone is welcome to review or leave a comment on an nf-core pull request - regardless of whether you are within the nf-core community or not.
 You also do not need to be in the nf-core GitHub organisation (although this is recommended).
 
 However, if you review a PR about a 'conceptual' question, a second technical review by another community member is required.


### PR DESCRIPTION
Replaces https://github.com/nf-core/website/pull/3461 due to weird GitHub issues

@netlify /docs/contributing/how_to_contribute_to_nf-core