### PR TITLE
Components - meta-map: replace remove with extract

### DIFF
--- a/sites/docs/src/content/docs/contributing/components/meta_map.md
+++ b/sites/docs/src/content/docs/contributing/components/meta_map.md
@@ -117,7 +117,7 @@ Here are some examples:
 // Add to map - adding two maps makes a new Map object
 ch.map { meta, files -> [ meta + [ single_end: files instanceof Path ], files ] }
 
-// Remove certain keys (and their entries) from a map
+// Extract certain keys (and their entries) from a map
 ch.map { meta, files -> [ meta.subMap( ['id','rg'] ), files ] }
   // OR by specifying what not to include
 ch.map { meta, files -> [ meta.findAll { ! it.key in ['single_end'] }, files ] }


### PR DESCRIPTION
As far as I understand, `subMap()` does not _remove_ the given keys and corresponding values from the map. Remove implies that what comes back is the map without those terms, but what comes back is only the specified parts of the map. I think to actually _remove_ k/v pair from the map one would have to:

```
ch.map { meta, files -> [meta - meta.subMap( ['id', 'rg'] ), files] }
```

@netlify /docs/contributing/components/meta_map