### PR TITLE
Update nf-core/detaxizer publication

### DIFF
--- a/sites/main-site/src/content/about/publications.mdx
+++ b/sites/main-site/src/content/about/publications.mdx
@@ -150,8 +150,8 @@ doi: [10.7717/peerj.9001](https://doi.org/10.7717/peerj.9001)
 <Altmetric doi="10.1101/2025.03.27.645632" />
 Jannik Seidel, Camill Kaipf, Daniel Straub, Sven Nahnsen
 
-[_bioRxiv_ 2025.03.27.645632](https://www.biorxiv.org/content/10.1101/2025.03.27.645632v1);
-doi: [10.1101/2025.03.27.645632](https://doi.org/10.1101/2025.03.27.645632)
+[NAR Genomics and Bioinformatics, Vol 7, Issue 3 (2025)](https://doi.org/10.1093/nargab/lqaf125);
+doi: [10.1093/nargab/lqaf125](https://doi.org/10.1093/nargab/lqaf125)
 :::
 
 ### [nf-core/diaproteomics](https://nf-co.re/diaproteomics)


### PR DESCRIPTION
The preprint of nf-core/detaxizer is now followed by the publication.