### PR TITLE
updated nf-core/scnanoseq citation to published paper

### DIFF
--- a/sites/main-site/src/content/about/publications.mdx
+++ b/sites/main-site/src/content/about/publications.mdx
@@ -369,11 +369,11 @@ doi: [10.1101/2021.08.16.456499](https://doi.org/10.1101/2021.08.16.456499)
 
 :::tip{.fa-newspaper title="scnanoseq: an nf-core pipeline for Oxford Nanopore single-cell RNA-sequencing"}
 
-<Altmetric doi="10.1101/2025.04.08.647887" />
-Austyn Trull, nf-core community, Elizabeth A. Worthey, Lara Ianov
+<Altmetric doi="10.1093/bioinformatics/btaf487" />
+Austyn Trull, Elizabeth A. Worthey, Lara Ianov
 
-[_bioRxiv_ (2025)](https://doi.org/10.1101/2025.04.08.647887)
-doi: [10.1101/2025.04.08.647887](https://doi.org/10.1101/2025.04.08.647887)
+[_Bioinformatics_ (2025)](https://doi.org/10.1093/bioinformatics/btaf487)
+doi: [10.1093/bioinformatics/btaf487](https://doi.org/10.1093/bioinformatics/btaf487)
 :::
 
 ### [nf-core/taxprofiler](https://nf-co.re/taxprofiler)


### PR DESCRIPTION
The citation of `nf-core/scnanoseq` has now been updated to the published version in *Bioinformatics*

@netlify /about/publications