### PR TITLE
Move Renuka to outreach alumni

### DIFF
--- a/sites/main-site/src/content/about/governance.mdx
+++ b/sites/main-site/src/content/about/governance.mdx
@@ -106,7 +106,6 @@ Core team members will appear as organization members on the GitHub organization
 <Profile username="alneberg">Johannes Alneberg</Profile>
 <Profile username="KevinMenden">Kevin Menden</Profile>
 <Profile username="olgabot">Olga Botvinnik</Profile>
-<Profile username="renbot-bio">Renuka Kudva</Profile>
 <Profile username="sven1103">Sven F.</Profile>
 
 ## Safety
@@ -195,6 +194,7 @@ The outreach leads will have access to community social media and YouTube accoun
 <Profile username="edmundmiller">Edmund Miller</Profile>
 <Profile username="pcantalupo">Paul Cantalupo</Profile>
 <Profile username="Xesus-Abalo">Xesús M. Abalo</Profile>
+<Profile username="renbot-bio">Renuka Kudva</Profile>
 
 ## Maintainers
 


### PR DESCRIPTION
I don't think Renuka was ever part of the core team. I guess she ended up in this list by accident as the about page, then governance page, got rearranged.

@netlify /about/governance