### PR TITLE
Enhance core team duties with resource links

### DIFF
--- a/sites/docs/src/content/docs/checklists/community_governance/core_team.mdx
+++ b/sites/docs/src/content/docs/checklists/community_governance/core_team.mdx
@@ -197,9 +197,9 @@ The core team has a weekly rotation 'on-call' system for community management of
 
 Duties includes:
 
-- Facilitating discussions and handling acceptance/rejection procedures on nf-core/proposals (pipelines, RFCs, SIGs, etc.)
-- Adding new community members to the GitHub organisation
-- Uploading test data to AWS S3 buckets for new pipelines
-- Uploading containers to quay.io
-- Distributing first release reviews
-- Activating Zenodo
+- Facilitating discussions and handling acceptance/rejection procedures on nf-core/proposals (pipelines, RFCs, SIGs, etc.) => [Github](http://github.com/nf-core/proposals) and [Slack](https://nfcore.slack.com/archives/CE6SDEDAA)
+- Adding new community members to the GitHub organisation => [Github](http://github.com/orgs/nf-core/people) and [Slack](https://nfcore.slack.com/archives/CEB982K2T)
+- Uploading test data to AWS S3 buckets for new pipelines => [Slack](https://nfcore.slack.com/archives/C09H6NYHR9T)
+- Uploading containers to [quay.io](https://quay.io/)
+- Distributing first release reviews => [Slack](https://nfcore.slack.com/archives/C08K66XCZSL)
+- Activating Zenodo => [Link](https://zenodo.org/account/settings/github/)


### PR DESCRIPTION
Updated core team duties with links to relevant resources.

@netlify /docs/checklists/community_governance/core_team