### PR TITLE
Added nf-co2footprint project to Barcelona Hackathon

### DIFF
--- a/sites/main-site/src/content/hackathon-projects/hackathon-october-2025/nf-co2footprint.md
+++ b/sites/main-site/src/content/hackathon-projects/hackathon-october-2025/nf-co2footprint.md
@@ -16,7 +16,6 @@ leaders:
     slack: https://nfcore.slack.com/archives/D08KCG9SRSL
 ---
 
-
 ## Summary
 
 The nf-co2footprint plugin estimates the CO₂ equivalent emissions of workflow runs. After our first stable release, we are now looking forward to push the integration of our plugin into as many pipelines as possible. We aim to raise individual and collective awareness within the nf-core community about the environmental impact of our computational work.


### PR DESCRIPTION
The nf-co2footprint aims to raise awareness for the CO2 footprint of Nextflow runs. Please help us to advance the integration of the plugin into the community, nf-core and with cloud providers.

@netlify events/2025/hackathon-barcelona#list-of-projects