### PR TITLE
feat: add PriorCons viral consensus integration proposal for hackathon

### DIFF
--- a/sites/main-site/src/content/hackathon-projects/hackathon-october-2025/consensus_integration_viralrecon.md
+++ b/sites/main-site/src/content/hackathon-projects/hackathon-october-2025/consensus_integration_viralrecon.md
@@ -6,6 +6,7 @@ slack: https://nfcore.slack.com/archives/C0110R22NH3
 leaders:
   germanvallejo:
     name: Germán Vallejo
+    slack: https://nfcore.slack.com/team/U095H3KMQJX
 ---
 
 ## Project Aim


### PR DESCRIPTION
Add PriorCons hackathon proposal for viral consensus integration in viralrecon pipeline.

@netlify /hackathon-projects/hackathon-october-2025/consensus_integration_viralrecon