### PR TITLE
Update genome biology paper detalis 

### DIFF
--- a/sites/main-site/src/content/about/publications.mdx
+++ b/sites/main-site/src/content/about/publications.mdx
@@ -10,11 +10,11 @@ Please [make a pull-request](https://github.com/nf-core/website/blob/main/sites/
 
 # The nf-core project
 
-Latest preprint, with updates to Nextflow and nf-core and a case study about adoption by EuroFAANG:
+Latest nf-core paper, with updates to Nextflow and nf-core and a case study about adoption by EuroFAANG and other communities:
 
 :::tip{.fa-newspaper title="Empowering bioinformatics communities with Nextflow and nf-core"}
 
-<Altmetric doi="10.1101/2024.05.10.592912" />
+<Altmetric doi="10.1186/s13059-025-03673-9" />
 Bjorn E. Langer, Andreia Amaral, Marie-Odile Baudement, Franziska Bonath, Mathieu Charles, Praveen Krishna Chitneedi,
 Emily L. Clark, Paolo Di Tommaso, Sarah Djebali, Philip A. Ewels, Sonia Eynard, James A. Fellows Yates, Daniel Fischer,
 Evan W. Floden, Sylvain Foissac, Gisela Gabernet, Maxime U. Garcia, Gareth Gillard, Manu Kumar Gundappa, Cervin Guyomar,
@@ -23,8 +23,8 @@ Lagarrigue, Delphine Lallias, Daniel J. Macqueen, Edmund Miller, Julia Mir-Pedro
 Nahnsen, Harshil Patel, Alexander Peltzer, Frederique Pitel, Yuliaxis Ramayo-Caldas, Marcel da Camara Ribeiro-Dantas,
 Dominique Rocha, Mazdak Salavati, Alexey Sokolov, Jose Espinosa-Carrasco, Cedric Notredame, nf-core community
 
-[_bioRxiv_ 2024.05.10.592912](https://www.biorxiv.org/content/10.1101/2024.05.10.592912v1);
-doi: [10.1101/2024.05.10.592912](https://doi.org/10.1101/2024.05.10.592912)
+[_Genome Biology_ 2024.05.10.592912](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-025-03673-9);
+doi: [10.1186/s13059-025-03673-9](https://doi.org/10.1186/s13059-025-03673-9)
 :::
 
 Main publication for the main nf-core paper, describing the community and framework:


### PR DESCRIPTION
Update with the details of the nf-core already published paper in Genome Biology (pre-print removed).