### PR TITLE
Update instructions for Zenodo record submission

### DIFF
--- a/sites/docs/src/content/docs/checklists/community_governance/core_team.mdx
+++ b/sites/docs/src/content/docs/checklists/community_governance/core_team.mdx
@@ -132,7 +132,7 @@ Post release:
 
 1.  [ ] Select **Github** in the dropdown menu of your account in Zenodo and find the relevant repository.
 2.  [ ] Click the Zenodo **Record** page for the release.
-3.  [ ] Find the **Communities** box on the record page and submit the record to the nf-core community.
+3.  [ ] Find the **Communities** box on the record page and submit the record to the nf-core community. (Google Chrome contains a graphical bug causing the **Communities** box not to show up, please use another browser if this happens to you)
 4.  [ ] Copy the DOI for **Cite all versions?** in the **Versions** tab.
 5.  [ ] Update files on the pipeline master branch:
     - `README.md`: Add the Zenodo Badge and update the **If you use this pipeline cite** section.


### PR DESCRIPTION
Added a note about a graphical bug in Google Chrome affecting the Communities box visibility.

@netlify /docs/checklists/community_governance/core_team