### PR TITLE
Add talk details for Bytesize event on LLMs

### DIFF
--- a/sites/main-site/src/content/events/2025/bytesize_LLM_use.md
+++ b/sites/main-site/src/content/events/2025/bytesize_LLM_use.md
@@ -1,0 +1,15 @@
+---
+title: "Bytesize: How to use LLMs for writing Nextflow pipelines"
+subtitle: TBD
+type: talk
+startDate: "2026-01-27"
+startTime: "13:00+01:00"
+endDate: "2026-01-27"
+endTime: "13:30+01:00"
+locations:
+  - name: Online
+    links:
+      - https://kth-se.zoom.us/j/68390542812
+---
+
+A range of members in the community showcase how they use LLMs when writing Nextflow pipelines.


### PR DESCRIPTION
This document outlines a talk on using LLMs for writing Nextflow pipelines.
Based on the discussions in the LLM RFC. We are still looking for speakers.

@netlify /events/2025/bytesize_LLM_use