### PR TITLE
Fix A11Y: Add aria-label to footer logo link for accessibility

### DIFF
--- a/sites/main-site/src/components/footer/Footer.astro
+++ b/sites/main-site/src/components/footer/Footer.astro
@@ -9,7 +9,7 @@ import IconSocial from "@components/IconSocial.astro";
         <div class="row align-items-center">
             <div class="text-center text-lg-start col-12 col-lg d-flex flex-column justify-content-between">
                 <div class="">
-                    <a href="/" class="text-decoration-none d-inline-block">
+                    <a href="/" class="text-decoration-none d-inline-block" aria-label="nf-core homepage">
                         <div class="hide-dark align-middle">
                             <NfCoreLogo />
                         </div>


### PR DESCRIPTION
### Description
This PR fixes an accessibility violation in [homapage](https://nf-co.re/) identified by the IBM Equal Access Accessibility Checker. The footer logo link was missing an accessible name, which could make it difficult for screen reader users to understand the link's purpose.

<img width="2560" height="923" alt="image" src="https://github.com/user-attachments/assets/05adc763-280c-4350-95b9-bac651097be3" />


### Changes
Added `aria-label="nf-core homepage"` to the footer logo link in Footer.astro

### Accessibility Impact
- Before: The link wrapping the nf-core logo had no text content or aria-label, resulting in an unnamed link that screen readers couldn't properly announce.
- After: Screen readers will now announce "nf-core homepage, link" when encountering this element, clearly communicating its purpose to users who rely on assistive technology.

### Additional Info
The patch submitted in this PR was generated by [A11YRepair](https://sites.google.com/view/a11yrepair/home), an automated Web Accessibility repair tool that I developed to address common accessibility violations in web applications. The generated fixes were manually reviewed and validated before submission.