### PR TITLE
Add 'strict-syntax-health' repo to ignored

### DIFF
--- a/sites/main-site/src/config/ignored_repos.yaml
+++ b/sites/main-site/src/config/ignored_repos.yaml
@@ -28,6 +28,7 @@ ignore_repos:
   - setup-nextflow
   - setup-nf-test
   - stats
+  - strict-syntax-health
   - sublime
   - tandemrepeat
   - test-datasets


### PR DESCRIPTION
In preparation for moving https://github.com/ewels/strict-syntax-health over to nf-core