### PR TITLE
Clarify hackathon hub hosting hours and flexibility

### DIFF
--- a/sites/main-site/src/content/events/2026/hackathon-march-2026/index.mdx
+++ b/sites/main-site/src/content/events/2026/hackathon-march-2026/index.mdx
@@ -142,9 +142,15 @@ Anyone is welcome to host a hub - you don't need to be an expert or have prior e
 
 What you'll need:
 
-- Access to a dedicated space for the duration of the event
+- Access to a dedicated space during your local working hours (e.g., 09:00-17:00)
 - Decent Wi-FI and a bunch of extension cables
 - Enthusiasm!
+
+:::note{title="Flexibility welcomed"}
+You don't need to be open 24/7 or even for all three days! Most hubs operate during typical office hours.
+If you can only host for one or two days, that's absolutely fine - any in-person participation is valuable.
+Adapt the schedule to work for you and your attendees.
+:::
 
 Any space will do: be it a meeting room for 5-10 people through to larger spaces to accommodate more.
 


### PR DESCRIPTION
## Summary
- Clarifies that hubs only need to operate during local working hours, not 24/7
- Adds note that hosting for fewer than 3 days is welcome

@netlify /events/2026/hackathon-march-2026