### PR TITLE
Adding Boston local hub for March 2026 hackathon

### DIFF
--- a/sites/main-site/src/content/events/2026/hackathon-march-2026/boston.md
+++ b/sites/main-site/src/content/events/2026/hackathon-march-2026/boston.md
@@ -17,23 +17,22 @@ layout: "@layouts/events/HackathonMarch2026.astro"
 
 Any bioinformatics enthusiasts in the Boston area are welcome to attend this local node of the nf-core hackathon!
 
-Contacts: 
+Contacts:
 
-* [Lei Ma](https://nfcore.slack.com/team/U08BH838T4J) (lei_ma@g.harvard.edu)
-* [Sakina Saif](https://nfcore.slack.com/team/U0893B06N3S)
-* [Samantha Klasfeld](https://nfcore.slack.com/team/U07CNE03MBQ)
+- [Lei Ma](https://nfcore.slack.com/team/U08BH838T4J) (lei_ma@g.harvard.edu)
+- [Sakina Saif](https://nfcore.slack.com/team/U0893B06N3S)
+- [Samantha Klasfeld](https://nfcore.slack.com/team/U07CNE03MBQ)
 
 ## What to do
 
-Join our [#region-boston](https://nfcore.slack.com/archives/C08F0JJ1R3M) channel on the nf-core Slack to discuss ideas and plan! This is where we'll be coordinating before and during the hackathon. 
+Join our [#region-boston](https://nfcore.slack.com/archives/C08F0JJ1R3M) channel on the nf-core Slack to discuss ideas and plan! This is where we'll be coordinating before and during the hackathon.
 
 ## Site Specific guidelines
 
 Venue TBD
 
-## Schedule 
+## Schedule
 
 Schedule TBD
 
 ## Projects
-


### PR DESCRIPTION
Hello everyone, first time submitting a PR to host the hackathon. Would love to get this hub up this week. Hoping to find a venue ASAP! 

@netlify /events/2026/hackathon-march-2026/boston