### PR TITLE
Add Seoul local hub for March 2026 hackathon

### DIFF
--- a/sites/main-site/src/content/events/2026/hackathon-march-2026/seoul.mdx
+++ b/sites/main-site/src/content/events/2026/hackathon-march-2026/seoul.mdx
@@ -10,10 +10,10 @@ endTime: "17:00+09:00"
 locations:
     - name: Centerfield East Tower
       address: |
-        231, Teheran-ro, Gangnam-gu,
-        Seoul, Republic of Korea
+          231, Teheran-ro, Gangnam-gu,
+          Seoul, Republic of Korea
       links:
-        - http://nextflow2026seoul.notion.site/
+          - http://nextflow2026seoul.notion.site/
       geoCoordinates: [37.503555, 127.041478]
       country: South Korea
       city: Seoul
@@ -38,6 +38,6 @@ The Seoul hub will be open **only on the last day** of the hackathon.
 
 If you want to join to the offline local hub, you should register for the entrance QR code too.
 
-The link will be provided later so please contact Jehee Lee(jhlee0637@gmail.com) before March. 
+The link will be provided later so please contact Jehee Lee(jhlee0637@gmail.com) before March.
 
 We have limited seats for the offline local hub so please register early to save your spot!


### PR DESCRIPTION
Hi! I am registering a new local hub in Seoul, South Korea for the March 2026 Hackathon.

- Location: Centerfield East Tower, Gangnam, Seoul
- Host: Jehee Lee
- Schedule: March 13 (Friday), 10:00 - 17:00 KST

I have added the `seoul.mdx` file as requested. Thanks!

@netlify /events/2026/hackathon-march-2026/seoul