### PR TITLE
Add explicit module granularity guidelines

### DIFF
--- a/sites/docs/src/content/docs/guidelines/components/modules.md
+++ b/sites/docs/src/content/docs/guidelines/components/modules.md
@@ -66,6 +66,27 @@ ext.args = { "--id ${meta.id}" }
 
 :::
 
+### Module granularity
+
+A module SHOULD represent a single command or single subcommand with distinct functionality.
+Unless absolutely necessary, the finest level of granularity is `<tool>` or `<tool>/<subtool>`.
+
+This is reflected in the naming of modules:
+
+- A tool with a single execution command uses the naming pattern `<tool>` (or `<tool>/<tool>` if the tool also has subcommands).
+- A tool with subcommands uses the naming pattern `<tool>/<subtool>`.
+- If a tool has mutually exclusive functionality controlled only by flags (rather than subcommands), the flag name can replace the subcommand in the module name.
+- If a tool has sub-sub-commands, each subcommand SHOULD be appended to the first subcommand.
+
+**Examples:**
+
+| Tool    | Scenario                                                                                               | Module name                  |
+| ------- | ------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| kraken2 | Primary execution command (`kraken2 <params>`), but tool also has subcommands                          | `kraken2/kraken2`            |
+| kraken2 | Build subcommand (`kraken2 build <params>`)                                                            | `kraken2/build`              |
+| ANGSD   | Mutually exclusive functionality controlled by flags (e.g. `-doCounts`, `-GL`) rather than subcommands | `angsd/docounts`, `angsd/gl` |
+| AWS CLI | Sub-sub-command (`aws s3 ls`)                                                                          | `aws/s3ls`                   |
+
 ### Use of multi-command piping
 
 Software that can be piped together SHOULD be added to separate module files


### PR DESCRIPTION
## Summary
- Add a new "Module granularity" section to the module specifications that explicitly defines the finest level of granularity for modules (`<tool>` or `<tool>/<subtool>`)
- Covers naming rules for: single tools, tools with subcommands, flag-based splitting (e.g. ANGSD), and sub-sub-commands (e.g. `aws s3 ls`)
- Includes an examples table with kraken2, ANGSD, and AWS CLI patterns

Previously this was only implicitly covered via the "Use of multi-command piping" section.

## Test plan
- [ ] Verify the new section renders correctly on the docs site
- [ ] Check that the examples table displays properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@netlify /docs/guidelines/components/modules