### PR TITLE
Updated London site hackathon 2026

### DIFF
--- a/sites/main-site/src/content/events/2026/hackathon-march-2026/london.mdx
+++ b/sites/main-site/src/content/events/2026/hackathon-march-2026/london.mdx
@@ -18,9 +18,10 @@ layout: "@layouts/events/HackathonMarch2026.astro"
 ---
 
 Attendees from outside UCL can attend, you will need to sign up.
+
 We only have space for ~40 people this year, so we will work on the basis of first come first served.
 We assume you already know the basics of Nextflow and a bit of nf-core to attend. The hackathon will not be a training event per se. But...
-We will be hosting a little nf-core pre hackathon training on the 5th of March. Details to come soon, for those who want to learn how to contribute.
+We will be hosting a little nf-core pre-hackathon training on the 5th of March for thse who have little/no experience with nf-core but want to contribute. Please, sign up [here](https://docs.google.com/forms/d/e/1FAIpQLSfbZdr_sz2LmFwITzCpacF8C2y-MhAqH6hjk2hiJIpgurfgeA/viewform?usp=header) for the pre-event training.
 
 Main contacts:
 Chris Wyatt ([ucbtcdr@ucl.ac.uk](mailto:ucbtcdr@ucl.ac.uk))


### PR DESCRIPTION
Added training information.

@netlify /events/2026/hackathon-march-2026/london