### PR TITLE
hackathon-kansascity-hub

### DIFF
--- a/sites/main-site/src/content/events/2026/hackathon-march-2026/university-of-kansas-medical-center.mdx
+++ b/sites/main-site/src/content/events/2026/hackathon-march-2026/university-of-kansas-medical-center.mdx
@@ -3,10 +3,10 @@ title: "nf-core Hackathon - March 2026 (University of Kansas Medical Center)"
 subtitle: "Local node of the nf-core hackathon in Kansas City, KS, USA"
 shortTitle: "🇺🇸 University of Kansas"
 type: "hackathon"
-startDate: "2026-03-11"
-startTime: "10:00-06:00"
+startDate: "2026-03-13"
+startTime: "09:00-06:00"
 endDate: "2026-03-13"
-endTime: "17:00-06:00"
+endTime: "15:00-06:00"
 locations:
     - name: University of Kansas Medical Center
       address: |
@@ -19,8 +19,12 @@ locations:
 layout: "@layouts/events/HackathonMarch2026.astro"
 ---
 
-Attendees from outside University of Kansas Medical Center **can** attend.
+Join the Department of Biostatistics & Data Science at KU Medical Center while we work through new Nextflow training documentation and updates on the nf-core/smrnaseq pipeline together, time permitting. Please note our different time for our local hub hackathon from the general hackathon.
+
+**TIME**: March 13, 2026 from 9AM to 3PM
+
+Attendees from outside University of Kansas Medical Center **can** attend. Email Rachel (see below) for more information.
 
 Main contact: Rachel Griffard-Smith ([rgriffard@kumc.edu](mailto:rgriffard@kumc.edu))
 
-Meeting room not yet booked, please check back later for more information.
+Meeting in Robinson, 5th floor in Department of Biostatistics & Data Science Conference Room.


### PR DESCRIPTION
Update more specific information for Kansas City Hackathon local hub

@netlify /events/2026/hackathon-march-2026/university-of-kansas-medical-center