### PR TITLE
Adding hackathon project

### DIFF
--- a/sites/main-site/src/content/hackathon-projects/hackathon-march-2026/Nextflow Google & K8s plugins
+++ b/sites/main-site/src/content/hackathon-projects/hackathon-march-2026/Nextflow Google & K8s plugins
@@ -1,0 +1,22 @@
+---
+title: Working on nextflow/plugins/nf-google & nf-k8s
+category: Nextflow
+intro_video: ""
+image: ""
+image_alt: ""
+leaders:
+  Rayan Hassaïne:
+    name: Rayan Hassaïne
+    slack: https://nfcore.slack.com/team/U06MQLLLC2C
+  Nicolas Vannieuwkerke:
+    name: Nicolas Vannieuwkerke
+    slack: https://nfcore.slack.com/team/U03CKGEU3LZ
+---
+
+This project focuses on improving the google and k8s plugins in Nextflow 
+
+### Where
+
+Preferably in person at the local Brussels, Belgium site - but anybody's welcome online as well.
+
+_We welcome contributors of all experience levels._


### PR DESCRIPTION
Adding hackathon project (nf-google & nf-k8s) to main site

@netlify /hackathon-projects/hackathon-march-2026/Nextflow