### PR TITLE
Updated London local site: Added organiser email

### DIFF
--- a/sites/main-site/src/content/events/2026/hackathon-march-2026/london.mdx
+++ b/sites/main-site/src/content/events/2026/hackathon-march-2026/london.mdx
@@ -24,11 +24,10 @@ We assume you already know the basics of Nextflow and a bit of nf-core to attend
 We will be hosting a little nf-core pre-hackathon training on the 5th of March for thse who have little/no experience with nf-core but want to contribute. Please, sign up [here](https://docs.google.com/forms/d/e/1FAIpQLSfbZdr_sz2LmFwITzCpacF8C2y-MhAqH6hjk2hiJIpgurfgeA/viewform?usp=header) for the pre-event training.
 
 Main contacts:
-- Chris Wyatt ([ucbtcdr@ucl.ac.uk](mailto:ucbtcdr@ucl.ac.uk))
-- Fernando Duarte ([f.frutos@ucl.ac.uk](mailto:f.frutos@ucl.ac.uk))
 
 - Chris Wyatt ([ucbtcdr@ucl.ac.uk](mailto:ucbtcdr@ucl.ac.uk))
 - Fernando Duarte ([f.frutos@ucl.ac.uk](mailto:f.frutos@ucl.ac.uk))
+- Maxime Laurent ([maxime@fullcirclelabs.bio](mailto:maxime@fullcirclelabs.bio))
 
 ## Projects
 


### PR DESCRIPTION
Added organiser email

@netlify /events/2026/hackathon-march-2026/london