### PR TITLE
Add Krakow site

### DIFF
--- a/sites/main-site/src/content/events/2026/hackathon-march-2026/krakow.md
+++ b/sites/main-site/src/content/events/2026/hackathon-march-2026/krakow.md
@@ -20,7 +20,7 @@ layout: "@layouts/events/HackathonMarch2026.astro"
 
 # Contacts
 
-Main contact: 
+Main contact:
 Mauro Saporita ([mauro.saporita@ardigen.com](mailto:mauro.saporita@ardigen.com))
 
 # Participation


### PR DESCRIPTION
Adding Ardigen's Office as local hub in Krakow for Hackathon 2026

@netlify /events/2026/hackathon-march-2026/krakow