### PR TITLE
Add Slack/Teams notification plugin docs

### DIFF
--- a/sites/docs/src/content/docs/checklists/community_governance/core_team.mdx
+++ b/sites/docs/src/content/docs/checklists/community_governance/core_team.mdx
@@ -22,6 +22,9 @@ Instructions for [nf-core pipeline](https://github.com/nf-core/proposals) approv
     - One member of the core team and one member of the maintainers team.
 5. [ ] Core: Verify that the pipeline name follows the [pipeline naming guidelines](/docs/guidelines/pipelines/requirements/workflow_name).
 6. [ ] Core: Create a slack channel with approved pipeline name.
+    - [ ] Invite the Slack bot to the channel (`/invite @Full test notifications`).
+          This is required for CI/CD Slack notifications via the [nf-slack plugin](https://github.com/seqeralabs/nf-slack).
+          The bot **will silently fail** if not invited.
     - [ ] Inform the new developer of the [next steps](https://nf-co.re/docs/tutorials/adding_a_pipeline/creating_a_pipeline#create-the-pipeline)
 7. [ ] Core: Add the main developers to
     - [ ] [#pipeline-maintainers](https://nfcore.slack.com/archives/C04QR0T3G3H)

--- a/sites/docs/src/content/docs/usage/Getting_started/introduction.md
+++ b/sites/docs/src/content/docs/usage/Getting_started/introduction.md
@@ -80,7 +80,7 @@ To run a pipeline:
 
 - Hyphens matter! Core Nextflow command-line options use one (`-`), whereas pipeline-specific parameters use two (`--`).
 - Specify `--email your@email.com` to receive emails when your pipeline completes (requires Nextflow [mail and notification configuration](https://www.nextflow.io/docs/latest/mail.html#mail-configuration)).
-- Specify `--hook_url YOUR-HOOK-URL` or set the `params.hook_url` in `nextflow.config` to receive notifications from your pipeline in Microsoft Teams or Slack. Learn how to set up an incoming webhook in [MS Teams](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook?tabs=dotnet) and in [Slack](https://api.slack.com/messaging/webhooks).
+- To receive notifications from your pipeline (e.g. on completion or failure), see the [nf-slack plugin](https://github.com/seqeralabs/nf-slack) for Slack or the [nf-teams plugin](https://github.com/nvnieuwk/nf-teams) for Microsoft Teams.
 - Include `-r <version-number>` to specify a release version explicitly. This guarantees the same run command will give the same results in future runs.
 - Use `-resume` to restart pipelines that did not complete. This uses cached results for successful tasks from the previous run, instead of executing all tasks from scratch.
 - Use `nextflow log` to find the names of all previous runs in your directory, then use `nextflow run <pipeline> -resume <run-name>` to restart a specific run.


### PR DESCRIPTION
This is requires the template updates to be merged: https://github.com/nf-core/tools/pull/4051

## Summary
- **Core team checklist**: Add step to invite `@Full test notifications` bot to new pipeline Slack channels (required for nf-slack CI notifications)
- **User-facing intro**: Replace deprecated `--hook_url` webhook tip with pointers to [nf-slack](https://github.com/seqeralabs/nf-slack) and [nf-teams](https://github.com/nvnieuwk/nf-teams) plugins

## Test plan
- [ ] Verify core team checklist renders correctly with the new sub-step
- [ ] Verify introduction page tip displays the plugin links properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@netlify /docs/checklists/community_governance/core_team