### PR TITLE
Create project nf-core/ampliseq for hackathon march 2026

### DIFF
--- a/sites/main-site/src/content/hackathon-projects/hackathon-march-2026/ampliseq.md
+++ b/sites/main-site/src/content/hackathon-projects/hackathon-march-2026/ampliseq.md
@@ -1,0 +1,27 @@
+---
+title: Working on nf-core/ampliseq
+category: pipelines
+intro_video: "https://youtu.be/a0VOEeAvETs"
+slack: https://nfcore.slack.com/archives/CEA7TBJGJ
+location: Tübingen and online
+image: ""
+image_alt: ""
+leaders:
+  d4straub:
+    name: Daniel Straub
+    slack: https://nfcore.slack.com/archives/CEA7TBJGJ
+---
+
+This project focuses on the pipeline nf-core/ampliseq for amplicon sequencing data processing and analysis.
+
+## Open tasks
+
+- Working on open issues, for example towards release [2.17.0](https://github.com/nf-core/ampliseq/milestone/21)
+- Discussing issues & needs in general and how to solve those
+- Anything that might come up during the hackathon
+
+### Where
+
+Online and in-person at the local Hub Tuebingen Germany.
+
+_We welcome contributors of all experience levels._


### PR DESCRIPTION
Making nf-core ampliseq project, at Tübingen but open to remote.

@netlify /hackathon-projects/hackathon-march-2026/ampliseq