### PR TITLE
Add nf-core/hic hackathon project (2026)

### DIFF
--- a/sites/main-site/src/content/hackathon-projects/hackathon-march-2026/hic.md
+++ b/sites/main-site/src/content/hackathon-projects/hackathon-march-2026/hic.md
@@ -1,7 +1,7 @@
 ---
 title: Improving and fixing issues in nf-core/hic
 category: pipelines
-location: "[ZS Copenhagen](https://nf-co.re/events/2026/hackathon-march-2026/zs-dk) (in-person)"
+location: "ZS Copenhagen"
 slack: "https://nfcore.slack.com/archives/CJ3UVAZFT"
 leaders:
   samuelruizperez:


### PR DESCRIPTION
Added a new project aimed at improving the nf-core/hic during the March, 2026 Hackathon.

@netlify /hackathon-projects/hackathon-march-2026/hic