### PR TITLE
Add Instanbul hackathon local site infromation to the website

### DIFF
--- a/sites/main-site/src/content/events/2026/hackathon-march-2026/istanbul.md
+++ b/sites/main-site/src/content/events/2026/hackathon-march-2026/istanbul.md
@@ -1,7 +1,7 @@
 ---
 title: "Hackathon - March 2026 (Istanbul Kent University)"
 subtitle: "Local node for the nf-core hackathon in Istanbul, Turkey"
-shortTitle: "Istanbul, Turkey"
+shortTitle: "🇹🇷 Istanbul, Turkey"
 type: "hackathon"
 startDate: "2026-03-11"
 startTime: "09:00+03:00"


### PR DESCRIPTION
Plans for 3 projects for beginners, intermediate and advanced Nextflow programmers are currently in the works and will be uploaded by Monday 1st March at the latest.

@netlify /events/2026/hackathon-march-2026/istanbul