### PR TITLE
Add Medellin site and project for hackaton mar 2026

### DIFF
--- a/sites/main-site/src/content/events/2026/hackathon-march-2026/medellin.mdx
+++ b/sites/main-site/src/content/events/2026/hackathon-march-2026/medellin.mdx
@@ -16,6 +16,7 @@ locations:
       city: Medellín
 layout: "@layouts/events/HackathonMarch2026.astro"
 ---
+
 Local event hosted by Loka at WeWork Medellín. We have limited spots and it is thought as an internal event for the Loka team, but if you are interested in attending please reach out to the contacts below.
 
 Note that the hosting would only last for the first and second day, so if you want to attend only the third day, you can do it online without any problem.
@@ -25,7 +26,7 @@ Note that the hosting would only last for the first and second day, so if you wa
 Main contacts:
 
 - [<i class="fab fa-slack"></i> Andres Florian](https://nfcore.slack.com/team/U08FS0W6SHZ) ([afflorianc@eafit.edu.co](mailto:afflorianc@eafit.edu.co))
-- [<i class="fab fa-slack"></i> Daniel Sabogal](https://nfcore.slack.com/team/U07TFP9D68P) 
+- [<i class="fab fa-slack"></i> Daniel Sabogal](https://nfcore.slack.com/team/U07TFP9D68P)
 
 # Projects
 

--- a/sites/main-site/src/content/hackathon-projects/hackathon-march-2026/new-modules.md
+++ b/sites/main-site/src/content/hackathon-projects/hackathon-march-2026/new-modules.md
@@ -23,7 +23,6 @@ The main modules to implement in the nf-core are:
 
 We may add new ideas or other modules to work on
 
-
 ---
 
 ## Goal


### PR DESCRIPTION
Added a new site and a hackaton project related to publishing new modules

@netlify /events/2026/hackathon-march-2026/medellin