### PR TITLE
Add `scnanoseq` hackathon project

### DIFF
--- a/sites/main-site/src/content/hackathon-projects/hackathon-march-2026/scnanoseq.md
+++ b/sites/main-site/src/content/hackathon-projects/hackathon-march-2026/scnanoseq.md
@@ -1,0 +1,32 @@
+---
+title: nf-core/scnanoseq
+category: pipelines
+slack: "https://nfcore.slack.com/archives/C03TUE2K6NS"
+leaders:
+  lianov:
+    name: Lara Ianov
+    slack: "https://nfcore.slack.com/team/U02BS98JV98"
+  atrull314:
+    name: Austyn Trull
+    slack: "https://nfcore.slack.com/team/U02D2QGSAGJ"
+---
+
+This project aims to make progress on needed updates for `scnanoseq`.
+
+We welcome contributors at any level of experience.
+
+## Goal
+
+Add new features and fixes to the pipeline and evaluate GPU implementation where possible.
+
+## Tasks
+
+1. Evaluate, review, test PR [#65](https://github.com/nf-core/scnanoseq/pull/65) for improvements linked to file compresion.
+2. Address Issue [#80](https://github.com/nf-core/scnanoseq/issues/80).
+3. Adress Issue [#83](https://github.com/nf-core/scnanoseq/issues/83).
+4. Review latest changes to `BLAZE`, identify improvements and adress issues or feature requests, e.g.: Issues [#75](https://github.com/nf-core/scnanoseq/issues/75) and [#87](https://github.com/nf-core/scnanoseq/issues/87).
+5. Evaluate GPU integration where possible (e.g.: `minimap2`).
+
+## Where
+
+Online.


### PR DESCRIPTION
This PR adds the `scnanoseq` hackathon project for the March 2026 event.

@netlify /hackathon-projects/hackathon-march-2026/scnanoseq