### PR TITLE
Modifying hackathon Seoul local hub information

### DIFF
--- a/sites/main-site/src/content/events/2026/hackathon-march-2026/seoul.mdx
+++ b/sites/main-site/src/content/events/2026/hackathon-march-2026/seoul.mdx
@@ -15,7 +15,7 @@ locations:
       links:
           - http://nextflow2026seoul.notion.site/
       geoCoordinates: [37.503555, 127.041478]
-      country: "South Korea"
+      country: Republic of Korea
       city: Seoul
 layout: "@layouts/events/HackathonMarch2026.astro"
 ---


### PR DESCRIPTION
I guess if I change the country name to 'Korea', I'll see the flag icon in [the list](https://nf-co.re/events/2026/hackathon-march-2026#registered-hubs).

<img width="516" height="205" alt="image" src="https://github.com/user-attachments/assets/04b3c0fe-1ead-4f05-8bf4-d26ac700bf60" />

Also  I changed some information about the Seoul Local hub.

@netlify /events/2026/hackathon-march-2026/seoul