### PR TITLE
Typo fixes for scnanoseq hackathon

### DIFF
--- a/sites/main-site/src/content/hackathon-projects/hackathon-march-2026/scnanoseq.md
+++ b/sites/main-site/src/content/hackathon-projects/hackathon-march-2026/scnanoseq.md
@@ -21,10 +21,10 @@ Add new features and fixes to the pipeline and evaluate GPU implementation where
 
 ## Tasks
 
-1. Evaluate, review, test PR [#65](https://github.com/nf-core/scnanoseq/pull/65) for improvements linked to file compresion.
+1. Evaluate, review, test PR [#65](https://github.com/nf-core/scnanoseq/pull/65) for improvements linked to file compression.
 2. Address Issue [#80](https://github.com/nf-core/scnanoseq/issues/80).
-3. Adress Issue [#83](https://github.com/nf-core/scnanoseq/issues/83).
-4. Review latest changes to `BLAZE`, identify improvements and adress issues or feature requests, e.g.: Issues [#75](https://github.com/nf-core/scnanoseq/issues/75) and [#87](https://github.com/nf-core/scnanoseq/issues/87).
+3. Address Issue [#83](https://github.com/nf-core/scnanoseq/issues/83).
+4. Review latest changes to `BLAZE`, identify improvements and address issues or feature requests, e.g.: Issues [#75](https://github.com/nf-core/scnanoseq/issues/75) and [#87](https://github.com/nf-core/scnanoseq/issues/87).
 5. Evaluate GPU integration where possible (e.g.: `minimap2`).
 
 ## Where


### PR DESCRIPTION
This PR fixes some typos I missed in the original push to the scnanoseq hackathon project.

@netlify /hackathon-projects/hackathon-march-2026/scnanoseq