### PR TITLE
Genomeqc project

### DIFF
--- a/sites/main-site/src/content/hackathon-projects/hackathon-march-2026/genomeqc.md
+++ b/sites/main-site/src/content/hackathon-projects/hackathon-march-2026/genomeqc.md
@@ -1,0 +1,28 @@
+---
+title: Working on nf-core/genomeqc
+category: pipelines
+slack: https://nfcore.slack.com/archives/C07LY51P4S2
+location: London and online
+leaders:
+  FernandoDuarteF:
+    name: Fernando
+    slack: https://nfcore.slack.com/team/U07GYKE10QL
+  Chriswyatt1:
+    name: Chris Wyatt
+    slack: https://nfcore.slack.com/team/U036T1L3KC6
+---
+
+This project focuses on the pipeline nf-core/genomeqc for comparing genomes and their assemblies. We have alot of people already using the pipeline for their work, but no first release. We also have a semi finished manuscript, so we want to make sure we are in a position to publish this work ASAP.
+
+## Open tasks
+
+- Working on open issues, for example towards release [1.0.0](https://github.com/nf-core/genomeqc/issues). We should prioritise what is left to do
+- Upgrade the topic channels for versions
+- Discussing issues & needs in general and how to solve those
+- Anything that might come up during the hackathon
+
+### Where
+
+Online and in-person at the local London UCL Stratford site.
+
+_We welcome contributors of all experience levels._


### PR DESCRIPTION
Added genomeqc project to board
I think I followed all the same structures as in the other projects. 

@netlify /hackathon-projects/hackathon-march-2026/genomeqc