### PR TITLE
Add Bern hub for March 2026 hackathon

### DIFF
--- a/sites/main-site/src/content/events/2026/hackathon-march-2026/bern.md
+++ b/sites/main-site/src/content/events/2026/hackathon-march-2026/bern.md
@@ -9,8 +9,7 @@ endDate: "2026-03-13"
 endTime: "17:00+01:00"
 locations:
   - name: University of Bern
-    address:
-      Room 028, Hochschulstrasse 4, 3012 Bern, Switzerland
+    address: Room 028, Hochschulstrasse 4, 3012 Bern, Switzerland
     links:
       - https://www.bioinformatics.unibe.ch/
     geoCoordinates: [46.95049367852778, 7.4374062197131305]


### PR DESCRIPTION
Added details for the Hackathon event at the University of Bern, including schedule and contact information.

@netlify /events/2026/hackathon-march-2026/bern