### PR TITLE
Config strict syntax: Replace github admonitions with astro

### DIFF
--- a/sites/docs/src/content/docs/tutorials/migrate_to_strict_syntax/config_strict_syntax.md
+++ b/sites/docs/src/content/docs/tutorials/migrate_to_strict_syntax/config_strict_syntax.md
@@ -165,7 +165,6 @@ params.random_var = {
 Don't forget to set the `.call()` here at the end.
 This makes sure the code is evaluated during config resolution.
 If you don't add `.call()`, the parameter will be a closure instead of the expected value.
-If you don't add `.call()`, the parameter will be a closure instead of the expected value.
 :::
 
 To prevent [nf-schema](https://github.com/nextflow-io/nf-schema) warnings during pipeline initialisation, you should also add the following to your config:


### PR DESCRIPTION


@netlify /docs/tutorials/migrate_to_strict_syntax/config_strict_syntax