### PR TITLE
Restrict most GitHub action workflows to the 'nf-core/website' repository

### DIFF
--- a/.github/workflows/blueskyfeedbot.yml
+++ b/.github/workflows/blueskyfeedbot.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   rss-to-bluesky:
     runs-on: ubuntu-latest
+    if: github.repository == 'nf-core/website'
     steps:
       - name: Generate cache key
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8


### PR DESCRIPTION
On Slack, @FriederikeHanssen or @KurayiChawatama have asked about the option to disable certain GitHub action workflows, since they kept sending notifications about failures that are to be expected due to a lack of credentials. 

This PR updates most GitHub Actions workflows to restrict them to the 'nf-core/website' repository. No manual disabling in forks will be required in the future.

Mind that I did not fully understand the rationale of all workflows, so some of the restricted may actually be beneficial to run on forks as well. Which we disable will therefore be subject to discussion in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds a repository guard to prevent the scheduled Bluesky feed workflow from running in forks; the main risk is unintentionally skipping legitimate runs if the repo name changes.
> 
> **Overview**
> **Restricts workflow execution to the upstream repo.** The `Bluesky FeedBot` GitHub Actions job now has a job-level condition (`if: github.repository == 'nf-core/website'`) so the scheduled RSS-to-Bluesky posting workflow does not run (and fail due to missing secrets) on forks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 601297623169a0dae42506797c9053efc1b92843. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->