### PR TITLE
Update quiz social time for March 2026 event

### DIFF
--- a/sites/main-site/src/content/events/2026/hackathon-march-2026/index.mdx
+++ b/sites/main-site/src/content/events/2026/hackathon-march-2026/index.mdx
@@ -106,7 +106,7 @@ We’ve kept the main schedule intentionally light to accommodate different time
     - AMER: 5 pm ET / 2 pm PDT
         - Join on Zoom, link will be posted in Slack
 - Quiz social
-    - TBD
+    - Thursday, March 12th, 4 pm CET / 11 am ET / 8 am PDT
 
 :::tip{title="Your local time"}
 


### PR DESCRIPTION
Updated quiz social time to Thursday, March 12th, 4 pm CET.

@netlify /events/2026/hackathon-march-2026