### PR TITLE
Change health table colnames

### DIFF
--- a/sites/pipelines/src/pages/pipeline_health.astro
+++ b/sites/pipelines/src/pages/pipeline_health.astro
@@ -160,7 +160,7 @@ const countTrue = (fn) => {
                                 <th
                                     colspan="2"
                                     class="small fw-normal text-center p-1 px-3"
-                                    title="nf-validation plugin should not be in nextflow.config"
+                                    title={`${plugin} plugin should be in nextflow.config`}
                                     data-bs-toggle="tooltip"
                                     data-bs-placement="top"
                                 >


### PR DESCRIPTION
This PR allow dynamic column names for the plugin presence check.
The test are checking for the presence of the plugins, while the column name was asking for absence.

Is it really the presence that we want ?

@netlify /pipeline_health