### PR TITLE
Add intro video to hackathon event webpage

### DIFF
--- a/sites/main-site/src/content/events/2026/hackathon-march-2026/index.mdx
+++ b/sites/main-site/src/content/events/2026/hackathon-march-2026/index.mdx
@@ -38,7 +38,7 @@ Join us in person or online **March 11-13, 2026**, for the nf-core hackathon! ðŸ
 
 :::
 
-<YouTube id="ktn2SwKfRPs" />
+<YouTube id="ktn2SwKfRPs" poster="https://i.ytimg.com/vi/ktn2SwKfRPs/maxresdefault.jpg" />
 
 ## Hybrid format: In-person hubs and online
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Content-only change to a single MDX event page; main risk is minor rendering/formatting issues if the embed component behaves unexpectedly.
> 
> **Overview**
> Adds an embedded YouTube intro video to the `events/2026/hackathon-march-2026` page by importing and rendering the `YouTube` component in the Welcome section.
> 
> Also removes the now-redundant text pointing readers to prior hackathon pages and makes a small formatting tweak in the Schedule intro (removing an unintended list item).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf4798f9bc90de89f5275fe1e8a6a4bfd39eff28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

@netlify /events/2026/hackathon-march-2026