### PR TITLE
docs-v2: port over new proposing pre-existing pipelines warnings

### DIFF
--- a/sites/docs/src/content/docs/contributing/contribute-new-pipelines.md
+++ b/sites/docs/src/content/docs/contributing/contribute-new-pipelines.md
@@ -46,9 +46,7 @@ To propose a new nf-core pipeline:
    - [#pipeline-maintainers](https://nfcore.slack.com/channels/pipeline-maintainers) for major change announcements and general pipeline development discussion.
    - [#release-review-trading](https://nfcore.slack.com/channels/release-review-trading) to coordinate the two reviews required for your first release.
 
-:::warning
-
-**Contributing a pre-existing pipeline**
+:::warning{title="Contributing a pre-existing pipeline"}
 
 In some cases, you might have a Nextflow pipeline built outside of nf-core that you believe would be a valuable addition to the community.
 Make sure to [start the discussion](https://github.com/nf-core/proposals/issues) as early as possible.


### PR DESCRIPTION
To close #3946 

Ported over changes from this PR: https://github.com/nf-core/website/pull/3636/changes

@netlify /docs/contributing/contribute-new-pipelines