### PR TITLE
Components for metromap added

### DIFF
--- a/sites/docs/src/content/docs/community/brand/workflow-schematics.md
+++ b/sites/docs/src/content/docs/community/brand/workflow-schematics.md
@@ -56,10 +56,6 @@ To open the nf-core component library:
 
 This will load the nf-core shapes into the sidebar without any CORS issues.
 
-```bash
-https://raw.githubusercontent.com/nf-core/website/refs/heads/main/sites/docs/src/assets/images/graphic_design_assets/workflow_schematics_components/generic/nf-core_components.xml
-```
-
 :::tip
 Components can also be accessed via [bioicons](https://bioicons.com/icons/cc-0/Chemo-_and_Bioinformatics/James-A--Fellows-Yates/metromap_style_pipeline_workflow_components.svg).
 :::


### PR DESCRIPTION
https://github.com/nf-core/website/issues/3952

I get 

```
Error loading file
File not found
```

When I try to open up the draw.io version of the metromap. This is for both the existing documentation but also in this branch

@netlify /docs/community/brand/workflow-schematics