### PR TITLE
docs: Rename contribution-types.md

### DIFF
--- a/sites/docs/src/content/docs/contributing/Contributor-types.md
+++ b/sites/docs/src/content/docs/contributing/Contributor-types.md
@@ -3,8 +3,6 @@ title: Pipeline contributor types
 subtitle: Understand contributor types
 ---
 
-<!-- TODO File/title should be renamed to be more descriptive that it's about classifying contributor types -->
-
 Each nf-core pipeline includes a `nextflow.config` file with a manifest that lists all pipeline contributors.
 The manifest includes a `contributions` attribute that describes what each person contributed to the pipeline.
 


### PR DESCRIPTION
Renamed file and fixed image. closes #3926 

@netlify /docs/contributing/Contributor-types