### PR TITLE
Clarify custom config precedence and nf-core note

### DIFF
--- a/sites/docs/src/content/docs/running/configuration/configuration-options.md
+++ b/sites/docs/src/content/docs/running/configuration/configuration-options.md
@@ -80,7 +80,7 @@ If not, follow the repository instructions or the tutorial to add your cluster.
 See [Run configuration](https://training.nextflow.io/latest/nextflow_run/03_config/) for a guided configuration tutorial.
 
 :::note
-All nf-core pipelines have a `conf/base.config` where default computational resource request are specified.
+All nf-core pipelines have a `conf/base.config` where default computational resource requests are specified.
 :::
 
 ### Custom configuration files


### PR DESCRIPTION
Add a warning that parameters in custom.config do not override nextflow.config and recommend using -params-file with YAML/JSON. Add a note that nf-core uses base.config for resource defaults. Remove the duplicated warning and added more links in "Additional resources" section to clean up the configuration options page.

@netlify /docs/running/configuration/configuration-options