### PR TITLE
docs: migrate module general spec updates into docs-v2

### DIFF
--- a/sites/docs/src/content/docs/specifications/components/modules/general.md
+++ b/sites/docs/src/content/docs/specifications/components/modules/general.md
@@ -79,12 +79,12 @@ This is reflected in the naming of modules:
 
 **Examples:**
 
-| Tool    | Scenario                                                                                                | Module name                  |
-| ------- | ------------------------------------------------------------------------------------------------------- | ---------------------------- |
-| kraken2 | Primary execution command (`kraken2 <params>`), but tool also has subcommands                           | `kraken2/kraken2`            |
-| kraken2 | Build subcommand (`kraken2 build <params>`)                                                             | `kraken2/build`              |
+| Tool    | Scenario                                                                                               | Module name                  |
+| ------- | ------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| kraken2 | Primary execution command (`kraken2 <params>`), but tool also has subcommands                          | `kraken2/kraken2`            |
+| kraken2 | Build subcommand (`kraken2 build <params>`)                                                            | `kraken2/build`              |
 | ANGSD   | Mutually exclusive functionality controlled by flags (e.g. `-doCounts`, `-GL`) rather than subcommands | `angsd/docounts`, `angsd/gl` |
-| AWS CLI | Sub-sub-command (`aws s3 ls`)                                                                           | `aws/s3ls`                   |
+| AWS CLI | Sub-sub-command (`aws s3 ls`)                                                                          | `aws/s3ls`                   |
 
 ## Use of multi-command piping
 


### PR DESCRIPTION
Closes #3960

Migrates the outstanding documentation updates from the two source PRs referenced in the issue into the docs-v2 target page (`sites/docs/src/content/docs/specifications/components/modules/general.md`).

### Changes made

From [#3769](https://github.com/nf-core/website/pull/3769):
- Added a new **Module granularity** section with naming rules (`<tool>`, `<tool>/<subtool>`, flag-based and sub-sub-command handling) and an example table covering kraken2, ANGSD, and AWS CLI

From [#3783](https://github.com/nf-core/website/pull/3783):
- The `nextflow lint` guidance was already migrated to the new `formatting.md` page by the upstream sync; no duplicate needed here

- Removed the `<!-- TODO migrate changes ... -->` comment at the top of the file

### Verification
Validated locally with `npm run dev --workspace sites/docs`:
- `http://localhost:4321/docs/specifications/components/modules/general` returned `200`
- "Module granularity" section appears in the table of contents and page body
- Table and bullet list render correctly

@christopher-hakkaart @jfy133 please review when you get a chance :)

@netlify /docs/specifications/components/modules/general