### PR TITLE
Add advisory example image and embed in docs

### DIFF
--- a/sites/docs/src/content/docs/contributing/contribute-new-pipelines.md
+++ b/sites/docs/src/content/docs/contributing/contribute-new-pipelines.md
@@ -29,6 +29,10 @@ You will need the following to get started:
 To contribute features, bug fixes, or improvements to existing nf-core pipelines, see [Contributing to existing pipelines](/docs/contributors/contribute-existing-pipelines).
 :::
 
+:::info
+If your proposal is turned down, you can still use the nf-core template, tooling, and components. See [developing external pipelines with nf-core](developing/external-use).
+:::
+
 ## Request a new pipeline
 
 To propose a new nf-core pipeline:

--- a/sites/docs/src/content/docs/contributing/project-proposals.mdx
+++ b/sites/docs/src/content/docs/contributing/project-proposals.mdx
@@ -115,6 +115,10 @@ A proposal remains open until a champion is assigned or after 2 months of inacti
 
 The core team may reject proposals that are infeasible or conflict with project goals, with explanation provided.
 
+:::tip
+If your proposal is turned down, you can still use the nf-core template, tooling, and components. See [developing external pipelines with nf-core](developing/external-use).
+:::
+
 #### Voting
 
 Proposals require 80% core team approval via comments on the issue.

--- a/sites/docs/src/content/docs/developing/external-use.md
+++ b/sites/docs/src/content/docs/developing/external-use.md
@@ -4,8 +4,6 @@ subtitle: Use nf-core code externally
 shortTitle: External use
 ---
 
-<!-- TODO: Add links to this page from contributing and developing pages, maybe move this to developing? -->
-
 Whenever possible, you should contribute to existing nf-core pipelines.
 However, in some cases, this may not be possible or appropriate.
 In this case, you should still use parts of nf-core best practices for your own non-nf-core pipeline.


### PR DESCRIPTION
Add Advisory image asset and update community/advisories.md to embed the example image closes #3909. Thanks @beumjin for the original PR, this just fixes the image path. 

@netlify /docs/community/advisories