### PR TITLE
Include execution best practice for Colab users

### DIFF
--- a/sites/docs/src/content/docs/running/advanced-topics/google-colab.md
+++ b/sites/docs/src/content/docs/running/advanced-topics/google-colab.md
@@ -112,7 +112,10 @@ Connect from VS Code desktop:
 4. Select your tunnel from the list
 
 :::tip{title="Execution Best Practice"}
-For the most stable experience, complete the VS Code integration and connect your tunnel _before_ running any pipeline code. Once connected, execute your Nextflow and nf-core commands directly within the VS Code integrated terminal rather than running them as Colab notebook cells. Running intensive pipeline commands in Colab cells while the tunnel is active can lead to unexpected VS Code disconnections.
+Complete the VS Code integration and connect your tunnel _before_ running any pipeline code.
+This provides the most stable experience.
+Once connected, execute your Nextflow and nf-core commands directly within the VS Code integrated terminal rather than running them as Colab notebook cells.
+Running intensive pipeline commands in Colab cells while the tunnel is active can lead to unexpected VS Code disconnections.
 :::
 
 ## Manage data and outputs


### PR DESCRIPTION
Added best practice tip for using VS Code with Colab.

@netlify /docs/running/advanced-topics/google-colab