### PR TITLE
Clean up software dependencies documentation

### DIFF
--- a/sites/docs/src/content/docs/get_started/environment_setup/software-dependencies.md
+++ b/sites/docs/src/content/docs/get_started/environment_setup/software-dependencies.md
@@ -85,5 +85,3 @@ Containers are recommended when possible.
 :::
 
 For installation instructions, see [Mamba installation](https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html)
-
-<!-- TODO: Add additional resources, if any -->


### PR DESCRIPTION
Removed TODO comment for additional resources. Not needed.

@netlify /docs/get_started/environment_setup/software-dependencies