### PR TITLE
Updates documentation on dynamic ext.args in nf-tests

### DIFF
--- a/sites/docs/src/content/docs/developing/components/ext-args.md
+++ b/sites/docs/src/content/docs/developing/components/ext-args.md
@@ -71,12 +71,11 @@ Set `ext.args` based on parameter settings:
 ```groovy
 process {
     withName: '.*:FASTQC_UMITOOLS_TRIMGALORE:UMITOOLS_EXTRACT' {
-        ext.args   = [
-                params.umitools_extract_method ? "--extract-method=${params.umitools_extract_method}" : '',
-                params.umitools_bc_pattern     ? "--bc-pattern='${params.umitools_bc_pattern}'" : '',
-                params.umitools_bc_pattern2    ? "--bc-pattern2='${params.umitools_bc_pattern2}'" : ''
-            ].join(' ').trim()
-        ]
+        ext.args   = { [
+            params.umitools_extract_method ? "--extract-method=${params.umitools_extract_method}" : '',
+            params.umitools_bc_pattern     ? "--bc-pattern='${params.umitools_bc_pattern}'" : '',
+            params.umitools_bc_pattern2    ? "--bc-pattern2='${params.umitools_bc_pattern2}'" : ''
+        ].minus("").join(' ') }
     }
 }
 ```
@@ -109,7 +108,7 @@ process {
             meta.single_end                 ? '' : '--unpaired-reads=discard --chimeric-pairs=discard',
             params.umitools_grouping_method ? "--method='${params.umitools_grouping_method}'" : '',
             params.umitools_umi_separator   ? "--umi-separator='${params.umitools_umi_separator}'" : ''
-        ].join(' ').trim() }
+        ].minus("").join(' ') }
         ext.prefix = { "${meta.id}.umi_dedup.sorted" }
     }
 }

--- a/sites/docs/src/content/docs/specifications/components/modules/general.md
+++ b/sites/docs/src/content/docs/specifications/components/modules/general.md
@@ -40,7 +40,7 @@ fastqc \\
         ext.args = { [                                                        // Assign a closure which returns a string
             '--quiet',
             params.fastqc_kmer_size ? "-k ${params.fastqc_kmer_size}" : ''    // Parameter-dependent values can be provided in this way
-        ].join(' ') }                                                         // Join converts the list to a string.
+        ].minus("").join(' ') }                                               // Join converts the list to a string.
         ext.prefix = { "${meta.id}" }                                         // A closure can be used to access variables defined in the script
     }
   }

--- a/sites/docs/src/content/docs/specifications/components/modules/testing.md
+++ b/sites/docs/src/content/docs/specifications/components/modules/testing.md
@@ -150,7 +150,7 @@ Supply the config only to the tests that use `params`, otherwise define `params`
 :::
 
 :::info
-Modules in pipelines are frequently configured with dynamic inputs. Test parameters do not support this. For example, 
+Modules in pipelines are frequently configured with dynamic inputs. Test parameters do not support this. For example,
 
 ```groovy {3} title="nextflow.config"
 process {
@@ -189,6 +189,7 @@ process {
   }
 }
 ```
+
 :::
 
 ## Skipping CI test profiles

--- a/sites/docs/src/content/docs/specifications/components/modules/testing.md
+++ b/sites/docs/src/content/docs/specifications/components/modules/testing.md
@@ -152,7 +152,7 @@ Supply the config only to the tests that use `params`, otherwise define `params`
 :::info
 Modules in pipelines are frequently configured with dynamic inputs. Test parameters do not support this. For example,
 
-```groovy {3} title="nextflow.config"
+```groovy {3-4} title="nextflow.config"
 process {
   withName: 'MODULE' {
     ext.args = { "--sample ${meta.id}" }
@@ -181,7 +181,7 @@ when {
 }
 ```
 
-```groovy {3} title="nextflow.config"
+```groovy {3-4} title="nextflow.config"
 process {
   withName: 'MODULE' {
     ext.args = params.module_args

--- a/sites/docs/src/content/docs/specifications/components/modules/testing.md
+++ b/sites/docs/src/content/docs/specifications/components/modules/testing.md
@@ -149,6 +149,48 @@ No other settings should go into this file.
 Supply the config only to the tests that use `params`, otherwise define `params` for every test including the stub test.
 :::
 
+:::info
+Modules in pipelines are frequently configured with dynamic inputs. Test parameters do not support this. For example, 
+
+```groovy {3} title="nextflow.config"
+process {
+  withName: 'MODULE' {
+    ext.args = { "--sample ${meta.id}" }
+    ext.prefix = { "${meta.id}_prefix" }
+  }
+}
+```
+
+would be implemented as follows:
+
+```groovy {4-6} title="main.nf.test"
+config './nextflow.config'
+
+when {
+  params {
+    module_args = '--sample test1' // `meta.id` is replaced with the value it would take once dynamically resolved
+  }
+  process {
+    """
+    input[0] = [
+      [ id:'test1', single_end:false ], // meta map
+      file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true)
+    ]
+    """
+  }
+}
+```
+
+```groovy {3} title="nextflow.config"
+process {
+  withName: 'MODULE' {
+    ext.args = params.module_args
+    ext.prefix = { "${meta.id}_prefix" } // Dynamic prefix configuration remains in the config
+  }
+}
+```
+:::
+
 ## Skipping CI test profiles
 
 If a module does not support a particular test profile, you can skip it by adding the path to corresponding section in `.github/skip_nf_test.json`.


### PR DESCRIPTION
- Updates docs to use `.minus()` instead of `.trim()` in `ext.args`.
- Adds info on dynamic parameter inputs in nf-tests. Resolves #4133

@netlify /docs/developing/components/ext-args