### PR TITLE
claude/slackbot-invite-docs-HLJkP

### DIFF
--- a/sites/docs/src/content/docs/community/governance/core-team.mdx
+++ b/sites/docs/src/content/docs/community/governance/core-team.mdx
@@ -185,12 +185,35 @@ It's recommended that a core team member transfers the DOI to the nf-core Zenodo
 
 ## Add new community members to the GitHub organisation
 
-To add a member to the nf-core GitHub organisation via the #github-invitations` channel
+New members request access to the nf-core GitHub organisation via a Slack workflow in the [#github-invitations](https://nfcore.slack.com/archives/CEB982K2T) channel.
+The **nf-core-bot** can process these requests directly from Slack.
+
+### Using the nf-core-bot (recommended)
+
+To invite a user from a workflow message in [#github-invitations](https://nfcore.slack.com/archives/CEB982K2T):
 
 1.  Verify the request is reasonable (i.e., clearly not spam)
-1.  Send an invitation via [nf-core github teams](https://github.com/orgs/nf-core/teams)
-1.  Add new member to the [nf-core contributors team](https://github.com/orgs/nf-core/teams/contributors)
-1.  Respond to the #github-invitations channel request by reacting with the ✅ emoji
+1.  Click the **more actions** menu (three dots **⋮**) on the workflow message
+1.  Select **Connect to apps** > **Add to GitHub org nf-core-bot**
+
+The bot automatically extracts the GitHub username from the workflow message and sends them an organisation invitation with membership in the **Collaborators** team.
+The bot will post a visible reply in the message thread confirming the invitation.
+
+Alternatively, you can use the slash command anywhere in Slack (works best from `#github-invitations`):
+
+```
+/nf-core github add @slack-user
+/nf-core github add github-username
+```
+
+### Manual process
+
+If the bot is unavailable, you can invite members manually:
+
+1.  Verify the request is reasonable (i.e., clearly not spam)
+1.  Send an invitation via [nf-core GitHub teams](https://github.com/orgs/nf-core/teams)
+1.  Add the new member to the [nf-core contributors team](https://github.com/orgs/nf-core/teams/contributors)
+1.  Respond to the request by reacting with the ✅ emoji
 
 ## Updating online bingo cards
 

--- a/sites/docs/src/content/docs/community/governance/core-team.mdx
+++ b/sites/docs/src/content/docs/community/governance/core-team.mdx
@@ -196,6 +196,8 @@ To invite a user from a workflow message in [#github-invitations](https://nfcore
 1.  Click the **more actions** menu (three dots **⋮**) on the workflow message
 1.  Select **Connect to apps** > **Add to GitHub org nf-core-bot**
 
+![Screenshot showing the Slack workflow message context menu: (1) click the more actions button, (2) select Connect to apps, (3) select Add to GitHub org nf-core-bot](../../../../assets/images/governance/slack-github-invite.png)
+
 The bot automatically extracts the GitHub username from the workflow message and sends them an organisation invitation with membership in the **Collaborators** team.
 The bot will post a visible reply in the message thread confirming the invitation.
 


### PR DESCRIPTION
Document how core team members can use the nf-core-bot to process
GitHub organisation invitations from Slack, including the message
shortcut and slash command workflows. Keeps the manual process as
a fallback.

https://claude.ai/code/session_01KRVBm3eFc85YJciv1EBhTf

@netlify /docs/community/governance/core-team