### PR TITLE
Update nf-tests instructions in deprecating-components.md

### DIFF
--- a/sites/docs/src/content/docs/developing/components/deprecating-components.md
+++ b/sites/docs/src/content/docs/developing/components/deprecating-components.md
@@ -35,6 +35,7 @@ an automatic update of the module/subworkflow is performed.
 
 ### Updating the nf-tests
 
+Remove anything in the setup block.
 The addition of `assert false` will mean the nf-test will always fail.
 The `then` part of the nf-test should be updated with the following code:
 


### PR DESCRIPTION
Clarify instructions for updating nf-tests by removing setup block.

@netlify /docs/developing/components/deprecating-components