### PR TITLE
docs(modules): document process_low_memory and label stacking

### DIFF
--- a/sites/docs/src/content/docs/specifications/components/modules/resource-requirements.md
+++ b/sites/docs/src/content/docs/specifications/components/modules/resource-requirements.md
@@ -12,14 +12,13 @@ The keywords "MUST", "MUST NOT", "SHOULD", etc. are to be interpreted as describ
 
 An appropriate resource `label` MUST be provided for the module as listed in the [nf-core pipeline template](https://github.com/nf-core/tools/blob/main/nf_core/pipeline-template/conf/base.config).
 
-The template defines two kinds of labels:
+The template (since nf-core/tools:4.1.0) defines two kinds of labels:
 
 - **Bundled labels** set CPU, memory and time together. Use exactly one per module: `process_single`, `process_low`, `process_medium`, or `process_high`.
 - **Modifier labels** override a single axis and SHOULD be stacked on top of a bundled label: `process_long` (extends time), `process_low_memory` (drops memory), `process_high_memory` (raises memory).
 
 When labels are stacked, later labels override earlier ones for any axis they set. This lets a module express a shape that none of the bundled labels covers on its own. For example, a CPU-bound but memory-light tool:
 
-```nextflow
 process FOO {
     label 'process_high'
     label 'process_low_memory'

--- a/sites/docs/src/content/docs/specifications/components/modules/resource-requirements.md
+++ b/sites/docs/src/content/docs/specifications/components/modules/resource-requirements.md
@@ -17,7 +17,7 @@ The template (since nf-core/tools:4.1.0) defines two kinds of labels:
 - **Bundled labels** set CPU, memory and time together. Use exactly one per module: `process_single`, `process_low`, `process_medium`, or `process_high`.
 - **Modifier labels** override a single axis and SHOULD be stacked on top of a bundled label: `process_long` (extends time), `process_low_memory` (drops memory), `process_high_memory` (raises memory).
 
-When labels are stacked, later labels override earlier ones for any axis they set. This lets a module express a shape that none of the bundled labels covers on its own. For example, a CPU-bound but memory-light tool:
+When a process matches more than one `withLabel:` block, Nextflow applies them in the order they appear in the config file - later blocks override earlier ones for any axis they set. The order of the `label` directives in the process itself does not affect precedence. The nf-core template defines bundled labels first and modifier labels after, so a process that stacks a modifier on top of a bundled label gets the modifier values:
 
 ```groovy title="main.nf"
 process FOO {
@@ -27,7 +27,7 @@ process FOO {
 }
 ```
 
-resolves to the CPU and time defaults of `process_high` with the memory of `process_low_memory`.
+This resolves to the CPU and time defaults of `process_high` with the memory of `process_low_memory`.
 
 ## Source of multiple threads or cores value
 

--- a/sites/docs/src/content/docs/specifications/components/modules/resource-requirements.md
+++ b/sites/docs/src/content/docs/specifications/components/modules/resource-requirements.md
@@ -10,8 +10,24 @@ The keywords "MUST", "MUST NOT", "SHOULD", etc. are to be interpreted as describ
 
 ## Use of labels in modules
 
-An appropriate resource `label` MUST be provided for the module as listed in the [nf-core pipeline template](https://github.com/nf-core/tools/blob/master/nf_core/pipeline-template/conf/base.config#L29-L46).
-For example, `process_single`, `process_low`, `process_medium` or `process_high`.
+An appropriate resource `label` MUST be provided for the module as listed in the [nf-core pipeline template](https://github.com/nf-core/tools/blob/main/nf_core/pipeline-template/conf/base.config).
+
+The template defines two kinds of labels:
+
+- **Bundled labels** set CPU, memory and time together. Use exactly one per module: `process_single`, `process_low`, `process_medium`, or `process_high`.
+- **Modifier labels** override a single axis and SHOULD be stacked on top of a bundled label: `process_long` (extends time), `process_low_memory` (drops memory), `process_high_memory` (raises memory).
+
+When labels are stacked, later labels override earlier ones for any axis they set. This lets a module express a shape that none of the bundled labels covers on its own. For example, a CPU-bound but memory-light tool:
+
+```nextflow
+process FOO {
+    label 'process_high'
+    label 'process_low_memory'
+    ...
+}
+```
+
+resolves to the CPU and time defaults of `process_high` with the memory of `process_low_memory`.
 
 ## Source of multiple threads or cores value
 

--- a/sites/docs/src/content/docs/specifications/components/modules/resource-requirements.md
+++ b/sites/docs/src/content/docs/specifications/components/modules/resource-requirements.md
@@ -17,17 +17,8 @@ The template (since nf-core/tools:4.1.0) defines two kinds of labels:
 - **Bundled labels** set CPU, memory and time together. Use exactly one per module: `process_single`, `process_low`, `process_medium`, or `process_high`.
 - **Modifier labels** override a single axis and SHOULD be stacked on top of a bundled label: `process_long` (extends time), `process_low_memory` (drops memory), `process_high_memory` (raises memory).
 
-When a process matches more than one `withLabel:` block, Nextflow applies them in the order they appear in the config file - later blocks override earlier ones for any axis they set. The order of the `label` directives in the process itself does not affect precedence. The nf-core template defines bundled labels first and modifier labels after, so a process that stacks a modifier on top of a bundled label gets the modifier values:
-
-```groovy title="main.nf"
-process FOO {
-    label 'process_high'
-    label 'process_low_memory'
-    ...
-}
-```
-
-This resolves to the CPU and time defaults of `process_high` with the memory of `process_low_memory`.
+When a process matches more than one `withLabel:` block, Nextflow applies them in the order they appear in the config file. The order of the `label` directives in the process itself does not affect precedence.
+The nf-core template defines bundled labels first and modifier labels after, so modifier labels always overwrite the corresponding bundled value.
 
 ## Source of multiple threads or cores value
 

--- a/sites/docs/src/content/docs/specifications/components/modules/resource-requirements.md
+++ b/sites/docs/src/content/docs/specifications/components/modules/resource-requirements.md
@@ -19,6 +19,7 @@ The template (since nf-core/tools:4.1.0) defines two kinds of labels:
 
 When labels are stacked, later labels override earlier ones for any axis they set. This lets a module express a shape that none of the bundled labels covers on its own. For example, a CPU-bound but memory-light tool:
 
+```groovy title="main.nf"
 process FOO {
     label 'process_high'
     label 'process_low_memory'


### PR DESCRIPTION
## Summary

Companion docs change for nf-core/tools#4264 (Phil flagged in [his approval comment](https://github.com/nf-core/tools/pull/4264#pullrequestreview) that the new label needs a website mention).

Updates `sites/docs/src/content/docs/specifications/components/modules/resource-requirements.md` to:

- List all standard labels currently shipped in the template, grouped into:
  - **Bundled labels** (set CPU + memory + time): `process_single`, `process_low`, `process_medium`, `process_high`
  - **Modifier labels** (override one axis, stackable): `process_long`, `process_low_memory`, `process_high_memory`
- Document the label-stacking pattern enabled by modifier labels, with an example showing `process_high` + `process_low_memory` for CPU-bound but memory-light tools (the use case that motivated the new label).

Also unpins the `base.config` link from a stale line range and switches its branch reference from `master` to `main`.

## Why this scope

The bigger restructure of the resource-label scheme (orthogonal CPU/memory/time axes) is being discussed in [nf-core/proposals#139](https://github.com/nf-core/proposals/issues/139). This PR is intentionally limited to documenting what already shipped in nf-core/tools#4264 - it doesn't pre-empt the RFC.

## Test plan

- [ ] Prettier passes (verified locally with `prettier --check` against the file).
- [ ] Spec page renders without layout regressions on the deploy preview.
- [ ] Stacking example reads correctly to a module author who hasn't seen the pattern before.

@netlify /docs/specifications/components/modules/resource-requirements