### PR TITLE
Fix code block backticks

### DIFF
--- a/sites/main-site/src/content/blog/2026/parameter-types.md
+++ b/sites/main-site/src/content/blog/2026/parameter-types.md
@@ -137,7 +137,7 @@ This is a non-exhaustive list of parameters that belong to this category. This w
 
 Support for nested parameters has been silently 'deprecated' with the introduction of parameter types. This issue can be resolved by migrating `genomes` parameter in `conf/igenomes.config` to a `Map` structure instead of using nested parameters. e.g.:
 
-````groovy title="conf/igenomes.config"
+```groovy title="conf/igenomes.config"
 params.genomes {
     'GRCh38' {
         fasta = "..."
@@ -148,6 +148,7 @@ params.genomes {
         fai: "..."
     }
 }
+```
 
 should become:
 
@@ -162,7 +163,7 @@ params.genomes = [
         fai: "..."
     ]
 ]
-````
+```
 
 ### nf-core linting is complaining
 


### PR DESCRIPTION
Some missing code block backtips got a bit weird from the prettier fixes I think. Fixed here.

This is now two separate code blocks instead of one:

<img width="1588" height="1244" alt="CleanShot 2026-05-26 at 18 00 32@2x" src="https://github.com/user-attachments/assets/04899a8a-0d84-48b5-8e27-ec8063639a54" />


@netlify /blog/2026/parameter-types