### PR TITLE
Remove embedAt field from original mag bytesize

### DIFF
--- a/sites/main-site/src/content/events/2023/bytesize_mag.md
+++ b/sites/main-site/src/content/events/2023/bytesize_mag.md
@@ -7,7 +7,6 @@ startTime: "13:00+01:00"
 endDate: "2023-02-28"
 endTime: "13:30+01:00"
 youtubeEmbed: https://www.youtube.com/watch?v=IiorfDHeoLo
-embedAt: "mag"
 locations:
   - name: Online
     links:


### PR DESCRIPTION
As it didn't seem to append or replace this one when I Added the new mag video

@netlify /events/2023/bytesize_mag