### PR TITLE
Make visible nf-core policy publications, and better structure

### DIFF
--- a/sites/docs/src/content/docs/specifications/pipelines/recommendations/publication_credit.md
+++ b/sites/docs/src/content/docs/specifications/pipelines/recommendations/publication_credit.md
@@ -6,27 +6,53 @@ weight: 123
 
 The keywords "MUST", "MUST NOT", "SHOULD", etc. are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
+The nf-core community encourages wider dissemination of nf-core pipelines via publications and presentations.
+
 All pipeline publications and presentations, or those that describe pipelines, SHOULD give attribution to the nf-core community.
 
 All nf-core pipeline publications and presentations SHOULD cite [The nf-core framework for community-curated bioinformatics pipelines](https://www.nature.com/articles/s41587-020-0439-x):
 
-> Ewels, P.A., Peltzer, A., Fillinger, S. et al. The nf-core framework for community-curated bioinformatics pipelines. Nat Biotechnol 38, 276–278 (2020). https://doi.org/10.1038/s41587-020-0439-x
+> Ewels, P.A., Peltzer, A., Fillinger, S. et al. The nf-core framework for community-curated bioinformatics pipelines. Nat Biotechnol 38, 276–278 (2020). [https://doi.org/10.1038/s41587-020-0439-x](https://doi.org/10.1038/s41587-020-0439-x)
 
-**At a minimum**, the nf-core community should be thanked in the acknowledgment section. For example, the acknowledgement from the [nf-core/clipseq](https://doi.org/10.12688/wellcomeopenres.19453.1)) preprint:
+And [Empowering bioinformatics communities with Nextflow and nf-core](https://doi.org/10.1186/s13059-025-03673-9):
+
+> Langer, B. E., Amaral, A., Baudement, M.-O., Bonath, F., Charles, M., Chitneedi, P. K., Clark, E. L., Di Tommaso, P., Djebali, S., Ewels, P. A., Eynard, S., Fellows Yates, J. A., Fischer, D., Floden, E. W., Foissac, S., Gabernet, G., Garcia, M. U., Gillard, G., Gundappa, M. K., … Community, T. N.-C. (2025). Empowering bioinformatics communities with Nextflow and nf-core. Genome Biology, 26(1), 228. [https://doi.org/10.1186/s13059-025-03673-9](https://doi.org/10.1186/s13059-025-03673-9)
+
+## Community acknowledgment
+
+**At a minimum**, the nf-core community SHOULD be thanked in the acknowledgment section.
+For example, the acknowledgement from the [nf-core/clipseq](https://doi.org/10.12688/wellcomeopenres.19453.1) preprint:
 
 > We would also like to thank the nf-core team, in particular Harshil Patel, Phil Ewels and Maxime Garcia, for welcoming us to the nf-core community and their assistance in reviewing and releasing the pipeline. We would also like to thank the nf-core community for developing the nf-core infrastructure and resources for Nextflow pipelines. A full list of nf-core community members is available at https://nf-co.re/community.
 
-**Optionally**, the nf-core community can be included as a consortium co-author. This option is preferred when a pipeline has made extensive use of existing nf-core pipeline components (e.g., modules and subworkflows) written by other community members who were not directly involved in the pipeline itself. For example, see hgtseq: [A Standard Pipeline to Study Horizontal Gene Transfer](https://doi.org/10.3390/ijms232314512).
+## Co-authorship
 
-If members of the nf-core community have provided significant input to the creation or maintenance of a pipeline, please consider adding them as coauthors on the pipeline publication or presentation.
+### Whole community
+
+**Optionally**, the nf-core community MAY be included as a consortium coauthor.
+
+This option is preferred when a pipeline has made extensive use of existing nf-core pipeline components (e.g., modules and subworkflows) written by other community members who were not directly involved in the pipeline itself.
+For example, see hgtseq: [A Standard Pipeline to Study Horizontal Gene Transfer](https://doi.org/10.3390/ijms232314512).
+
+You can use the core team email address ([core@nf-co.re](mailto:core@nf-co.re)) as a contact email address if required by the journal.
+Ask the core team on Slack if need any more information.
+
+### Specific community members
+
+If members of the nf-core community have provided significant input to the creation or maintenance of a pipeline, you SHOULD consider adding them as coauthors.
 
 We also strongly recommend transparency when working on a project where the pipeline plays a significant role.
-If you plan to write a paper about a pipeline, share this with the community in the pipeline-specific channel on the nf-core Slack workspace prior to and during the manuscript's writing, and invite contributors to self-report their roles and discuss authorship expectations within the project group.
+If you plan to write a paper about a pipeline, you SHOULD share this with the community in the pipeline-specific channel on the nf-core Slack workspace prior to and during the manuscript's writing.
+
+You SHOULD invite contributors to self-report their roles and discuss authorship expectations within the project group.
 
 If your pipeline publication or presentation is an extension of a community pipeline, please discuss authorship with the main developers.
 
+### Requirements for specific contributor co-authorship
+
 Determining fair guidelines for authorship in community-driven projects, especially those involving diverse contributors, can be challenging.
-Based on [ICMJE's recommendations](https://www.icmje.org/recommendations/) for authorship, we suggest you evaluate the inclusion of contributors as co-authors based on the following four criteria:
+
+Based on [ICMJE's recommendations](https://www.icmje.org/recommendations/) for authorship, we suggest you evaluate the inclusion of contributors as coauthors based on the following four criteria:
 
     - Substantial contributions to the conception or design of the pipeline; or the acquisition, analysis, or interpretation of data used to test/demo the pipeline; AND
     - Drafting the work or reviewing it critically for important intellectual content; AND

--- a/sites/docs/src/content/docs/specifications/pipelines/recommendations/publication_credit.md
+++ b/sites/docs/src/content/docs/specifications/pipelines/recommendations/publication_credit.md
@@ -6,7 +6,7 @@ weight: 123
 
 The keywords "MUST", "MUST NOT", "SHOULD", etc. are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
-The nf-core community encourages wider dissemination of nf-core pipelines via publications and presentations.
+**The nf-core community encourages wider dissemination of nf-core pipelines via publications and presentations.**
 
 All pipeline publications and presentations, or those that describe pipelines, SHOULD give attribution to the nf-core community.
 

--- a/sites/main-site/src/content/about/publications.mdx
+++ b/sites/main-site/src/content/about/publications.mdx
@@ -8,6 +8,9 @@ import Altmetric from "@components/Altmetric.astro";
 Do you know of an nf-core publication that we're missing?
 Please [make a pull-request](https://github.com/nf-core/website/blob/main/sites/main-site/src/content/about/publications.mdx).
 
+Planning on writing your own nf-core publication?
+See the [make a guidelines](https://nf-co.re/docs/specifications/pipelines/recommendations/publication_credit).
+
 # The nf-core project
 
 Latest nf-core paper, with updates to Nextflow and nf-core and a case study about adoption by EuroFAANG:


### PR DESCRIPTION


@netlify /docs/specifications/pipelines/recommendations/publication_credit