### PR TITLE
docs(specs): clarify module output naming when format suffix is generic

### DIFF
--- a/sites/docs/src/content/docs/specifications/components/modules/naming-conventions.md
+++ b/sites/docs/src/content/docs/specifications/components/modules/naming-conventions.md
@@ -52,3 +52,5 @@ Output file (and/or directory) names SHOULD consist of only `${prefix}` and the 
   ```nextflow
   def prefix = task.ext.prefix ?: "${meta.id}_sorted"
   ```
+
+- When the output format suffix is generic (e.g. `.csv.gz`, `.tsv`, `.bed.gz`) and the module receives input files with the same suffix, include a type descriptor in the output glob pattern rather than relying solely on the default prefix. For example, prefer `path("${prefix}.metagene.csv.gz")` over `path("${prefix}.csv.gz")`. Without a descriptor, a user setting `ext.prefix` to a value that matches an input filename stem will produce a glob that captures the staged input file as output. In these cases the descriptor SHOULD be baked into the default prefix as a fallback (e.g. `task.ext.prefix ?: "${meta.id}.metagene"`), but kept in the glob pattern too for safety.


### PR DESCRIPTION
## Summary

- Adds a clarification bullet to the "Command file output naming" spec for the case where a module's output format suffix is generic (e.g. `.csv.gz`, `.tsv`, `.bed.gz`) and shared with its inputs.
- In this case, a type descriptor SHOULD remain in the output glob pattern (not just the default prefix) to prevent the glob from matching staged input files when a user sets `ext.prefix` arbitrarily.

### Motivation

The current spec says outputs SHOULD be `${prefix}.<format-suffix>` only, which works well for unambiguous suffixes like `.bam` or `.fq.gz`. But for generic suffixes, moving the descriptor entirely into the prefix creates a silent failure mode: if a user sets the same `ext.prefix` across a chain of modules, the output glob of a downstream module can match the staged output of the upstream module (which was passed in as input), causing Nextflow to capture the input file as output.

Example: a user sets `ext.prefix = "sample"` on both `extractmetageneprofiles` (outputs `sample.csv.gz`) and `estimatemetagenebayesfactors` (takes that file as input, also outputs `${prefix}.csv.gz`). The second module's glob matches both the input and the intended output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@netlify /docs/specifications/components/modules/naming-conventions