### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the **nf-core website**: an [Astro](https://astro.build/) static-site
+mono-repo split into independent sub-sites under `sites/*` wired together with npm
+workspaces. The update script runs `npm install` on startup (installs both the root
+and all workspace dependencies), so the notes below focus on running/testing.
+
+### Services (Astro sub-sites)
+
+Each `sites/<name>` is its own Astro app with the same scripts (`dev`, `build`,
+`test`). Run one at a time; they are disjoint, so cross-site links (e.g. opening
+`/pipelines` while running `main-site`) will 404 in dev — this is expected.
+
+- `sites/main-site` – main website (blog, events, components). Works with no token.
+- `sites/docs` – documentation. Works with no token.
+- `sites/pipelines`, `sites/modules-subworkflows`, `sites/configs`,
+  `sites/pipeline-results`, `sites/stickers` – pull data from the GitHub API.
+  Pre-built JSON in `public/` lets them run for basic dev, but to rebuild data or
+  avoid API rate limits add a `GITHUB_TOKEN` to a root `.env` and symlink it into
+  the sub-site, e.g. `ln -s .env sites/pipelines/.env` (see `README.md`).
+
+### Run (dev)
+
+`npm run dev --workspace sites/main-site` serves at http://localhost:4321/.
+Add `-- --host` to expose it on the network. First start is slow (~10s) because
+Astro syncs content and optimizes deps.
+
+### Lint
+
+The CI lint gate is **prettier driven by prek** (the `@j178/prek` binary), only over
+`*.astro,*.svelte,*.mdx,*.md,*.yml,*.yaml`. Run it with
+`./node_modules/.bin/prek run --all-files`.
+Note: the per-workspace `npm run lint` (`prettier --check .`) scans *all* files
+including vendored FontAwesome CSS and reports long-standing warnings that are NOT
+part of the CI gate — prefer `prek` to judge lint status.
+
+### Test
+
+Playwright lives in `sites/main-site`: `npm run test -w sites/main-site`
+(add `-- --project=chromium` to run a single browser). Browsers must be installed
+once with `npx playwright install --with-deps chromium`. Locally the tests hit the
+dev server at `http://localhost:4321`, so start `main-site` dev first. CI instead
+points `PLAYWRIGHT_TEST_BASE_URL` at a Netlify deploy preview.
+
+### Gotcha
+
+Root devDependencies (`prek`, `prettier`) are only installed by plain `npm install`,
+**not** `npm install --workspaces` (which the README mentions). The update script
+uses plain `npm install` for this reason. `npm install` may add harmless `"peer": true`
+annotations to `package-lock.json`; leave those uncommitted.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Astro syncs content and optimizes deps.
 The CI lint gate is **prettier driven by prek** (the `@j178/prek` binary), only over
 `*.astro,*.svelte,*.mdx,*.md,*.yml,*.yaml`. Run it with
 `./node_modules/.bin/prek run --all-files`.
-Note: the per-workspace `npm run lint` (`prettier --check .`) scans *all* files
+Note: the per-workspace `npm run lint` (`prettier --check .`) scans _all_ files
 including vendored FontAwesome CSS and reports long-standing warnings that are NOT
 part of the CI gate — prefer `prek` to judge lint status.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for the nf-core website (Astro mono-repo with npm workspaces) and documents durable startup/run notes for future cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section describing the sub-sites, how to run/lint/test them, and non-obvious gotchas.
- Configures the VM update script to `npm install` (installs both root and workspace dependencies; `--workspaces` alone misses root devDeps like `prek`/`prettier`).

No application code was modified.

## Verification

- Dependencies installed via `npm install`.
- `main-site` dev server runs at `http://localhost:4321/` (HTTP 200, title `nf-core`).
- Lint (CI gate): `prek run --all-files` → prettier Passed.
- Tests: `npm run test -w sites/main-site -- --project=chromium` → 4 passed.
- Hello-world: browsed the live dev site in Chrome — homepage rendered, dark-mode toggle worked, navigated to `/about`.

[nf_core_website_dev_demo.mp4](https://cursor.com/agents/bc-4b82c6a9-3c46-45a4-a78e-5d75db5265a7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnf_core_website_dev_demo.mp4)

[Homepage (light mode)](https://cursor.com/agents/bc-4b82c6a9-3c46-45a4-a78e-5d75db5265a7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_light.webp)
[Homepage (dark mode)](https://cursor.com/agents/bc-4b82c6a9-3c46-45a4-a78e-5d75db5265a7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_dark.webp)
[About page](https://cursor.com/agents/bc-4b82c6a9-3c46-45a4-a78e-5d75db5265a7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fabout_page.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b82c6a9-3c46-45a4-a78e-5d75db5265a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b82c6a9-3c46-45a4-a78e-5d75db5265a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

