### PR TITLE
Fix internal links in external-use.md

### DIFF
--- a/sites/docs/src/content/docs/developing/external-use.md
+++ b/sites/docs/src/content/docs/developing/external-use.md
@@ -39,7 +39,7 @@ Replace the following:
   :::warning
   If you still wish to use the `nf-core tools` linting functionality, this may cause linting failures.
   Create a `.nf-core.yml` file that allows you to ignore or skip certain lint tests.
-  See [linting config](../../nf-core-tools/CLI/pipelines/lint#linting-config) for more information.
+  See [linting config](../nf-core-tools/CLI/pipelines/lint#linting-config) for more information.
   :::
 
 ### `README`
@@ -111,4 +111,4 @@ Rename the following:
 
 - `ci.yml`: The name of your pipeline (rather than `nf-core CI tests`)
 
-See [Setting custom remotes](../../developing/components/custom-remotes).
+See [Setting custom remotes](./components/custom-remotes).

--- a/sites/docs/src/content/docs/nf-core-tools/CLI/subworkflows/create.md
+++ b/sites/docs/src/content/docs/nf-core-tools/CLI/subworkflows/create.md
@@ -8,7 +8,7 @@ weight: 60
 This command creates a new nf-core subworkflow from the nf-core subworkflow template.
 This ensures that your subworkflow follows the nf-core guidelines.
 The template contains extensive `TODO` messages to walk you through the changes you need to make to the template.
-See the [subworkflow documentation](https://nf-co.re/docs/contributing/subworkflows) for more details around creating a new subworkflow, including rules about nomenclature and a step-by-step guide.
+See the [subworkflow documentation](https://nf-co.re/docs/specifications/components/subworkflows/general) for more details around creating a new subworkflow, including rules about nomenclature and a step-by-step guide.
 
 You can create a new subworkflow using `nf-core subworkflows create`.
 


### PR DESCRIPTION
The (relative) links on the page about [external use of nf-core](https://nf-co.re/docs/developing/external-use) don't seem to work as intended. This should fix it I hope.

@netlify /docs/developing/external-use