### PR TITLE
Add LinkedIn newsletter subscription links across pages

### DIFF
--- a/sites/main-site/src/pages/index.astro
+++ b/sites/main-site/src/pages/index.astro
@@ -151,7 +151,10 @@ import AnnouncementBanner from "@components/navbar/AnnouncementBanner.astro";
             <div class="col-xl-4 col-lg-7">
                 <NewsletterSignup compact={true} />
                 <p class="small text-body-secondary mt-2 mb-0">
-                    <a href="/newsletter/subscribe">More about the newsletter</a>
+                    <a href="/newsletter/subscribe">More about the newsletter</a> &middot; or
+                    <a href="https://www.linkedin.com/newsletters/nf-core-7474718981564706816/" target="_blank" rel="noopener"
+                        ><i class="fab fa-linkedin me-1"></i>follow on LinkedIn</a
+                    >
                 </p>
             </div>
         </div>

--- a/sites/main-site/src/pages/index.astro
+++ b/sites/main-site/src/pages/index.astro
@@ -152,8 +152,10 @@ import AnnouncementBanner from "@components/navbar/AnnouncementBanner.astro";
                 <NewsletterSignup compact={true} />
                 <p class="small text-body-secondary mt-2 mb-0">
                     <a href="/newsletter/subscribe">More about the newsletter</a>, or
-                    <a href="https://www.linkedin.com/newsletters/nf-core-7474718981564706816/" target="_blank" rel="noopener"
-                        ><i class="fab fa-linkedin me-1"></i>follow on LinkedIn</a
+                    <a
+                        href="https://www.linkedin.com/newsletters/nf-core-7474718981564706816/"
+                        target="_blank"
+                        rel="noopener"><i class="fab fa-linkedin me-1"></i>follow on LinkedIn</a
                     >
                 </p>
             </div>

--- a/sites/main-site/src/pages/index.astro
+++ b/sites/main-site/src/pages/index.astro
@@ -151,7 +151,7 @@ import AnnouncementBanner from "@components/navbar/AnnouncementBanner.astro";
             <div class="col-xl-4 col-lg-7">
                 <NewsletterSignup compact={true} />
                 <p class="small text-body-secondary mt-2 mb-0">
-                    <a href="/newsletter/subscribe">More about the newsletter</a> &middot; or
+                    <a href="/newsletter/subscribe">More about the newsletter</a>, or
                     <a href="https://www.linkedin.com/newsletters/nf-core-7474718981564706816/" target="_blank" rel="noopener"
                         ><i class="fab fa-linkedin me-1"></i>follow on LinkedIn</a
                     >

--- a/sites/main-site/src/pages/newsletter/index.astro
+++ b/sites/main-site/src/pages/newsletter/index.astro
@@ -39,8 +39,10 @@ const latest = months[0];
             <NewsletterSignup />
             <p class="small text-body-secondary mt-3 mb-0">
                 If you prefer, you can read and subscribe to the newsletter on
-                <a href="https://www.linkedin.com/newsletters/nf-core-7474718981564706816/" target="_blank" rel="noopener"
-                    ><i class="fab fa-linkedin me-1"></i>LinkedIn</a
+                <a
+                    href="https://www.linkedin.com/newsletters/nf-core-7474718981564706816/"
+                    target="_blank"
+                    rel="noopener"><i class="fab fa-linkedin me-1"></i>LinkedIn</a
                 >.
             </p>
         </div>

--- a/sites/main-site/src/pages/newsletter/index.astro
+++ b/sites/main-site/src/pages/newsletter/index.astro
@@ -38,7 +38,7 @@ const latest = months[0];
         <div class="card-body p-4">
             <NewsletterSignup />
             <p class="small text-body-secondary mt-3 mb-0">
-                Prefer LinkedIn? You can read and subscribe to the same newsletter on
+                If you prefer, you can read and subscribe to the newsletter on
                 <a href="https://www.linkedin.com/newsletters/nf-core-7474718981564706816/" target="_blank" rel="noopener"
                     ><i class="fab fa-linkedin me-1"></i>LinkedIn</a
                 >.

--- a/sites/main-site/src/pages/newsletter/index.astro
+++ b/sites/main-site/src/pages/newsletter/index.astro
@@ -37,6 +37,12 @@ const latest = months[0];
     <div class="card border-secondary mb-4">
         <div class="card-body p-4">
             <NewsletterSignup />
+            <p class="small text-body-secondary mt-3 mb-0">
+                Prefer LinkedIn? You can read and subscribe to the same newsletter on
+                <a href="https://www.linkedin.com/newsletters/nf-core-7474718981564706816/" target="_blank" rel="noopener"
+                    ><i class="fab fa-linkedin me-1"></i>LinkedIn</a
+                >.
+            </p>
         </div>
     </div>
 

--- a/sites/main-site/src/pages/newsletter/subscribe.astro
+++ b/sites/main-site/src/pages/newsletter/subscribe.astro
@@ -15,6 +15,14 @@ import NewsletterSignup from "@components/newsletter/NewsletterSignup.astro";
             <div class="card border-secondary mb-4">
                 <div class="card-body p-4">
                     <NewsletterSignup compact={true} />
+                    <p class="small text-body-secondary mt-3 mb-0">
+                        If you prefer, you can read and subscribe to the same newsletter on
+                        <a
+                            href="https://www.linkedin.com/newsletters/nf-core-7474718981564706816/"
+                            target="_blank"
+                            rel="noopener"><i class="fab fa-linkedin me-1"></i>LinkedIn</a
+                        >.
+                    </p>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
Added LinkedIn newsletter subscription links to the newsletter signup sections across the main website, providing users with an alternative way to subscribe and follow the nf-core newsletter.

## Key Changes
- **Newsletter subscribe page** (`newsletter/subscribe.astro`): Added a note below the signup form directing users to the LinkedIn newsletter option with a direct link
- **Newsletter index page** (`newsletter/index.astro`): Added similar LinkedIn subscription link below the main newsletter signup component
- **Homepage** (`index.astro`): Updated the newsletter section to include a LinkedIn follow link alongside the existing "More about the newsletter" link

## Implementation Details
- All LinkedIn links point to the same newsletter: `https://www.linkedin.com/newsletters/nf-core-7474718981564706816/`
- Links open in a new tab with `target="_blank"` and include `rel="noopener"` for security
- LinkedIn icon (`fab fa-linkedin`) is included with appropriate spacing (`me-1` margin)
- Text styling uses Bootstrap classes (`small text-body-secondary`) for consistency with existing design
- The messaging varies slightly based on context ("read and subscribe" vs "follow on LinkedIn") while maintaining clarity

https://claude.ai/code/session_01KzhW9ThTTUpzmJW5BaWXo9

@netlify 