### PR TITLE
Filter empty newsletter months from publication

### DIFF
--- a/sites/main-site/src/pages/newsletter/index.astro
+++ b/sites/main-site/src/pages/newsletter/index.astro
@@ -3,17 +3,10 @@ import PageLayout from "@layouts/PageLayout.astro";
 import NewsletterSignup from "@components/newsletter/NewsletterSignup.astro";
 import { getCollection } from "astro:content";
 import pipelines_json from "@public/pipelines.json";
-import { getNewsletterMonths, getMonthName } from "@utils/newsletter";
-
-let blogPosts = await getCollection("blog");
-blogPosts = blogPosts.filter((post) => new Date(post.data.pubDate) < new Date());
-
-let events = await getCollection("events");
-events = events.filter((e) => e.id.split("/").length === 2);
+import { getPublishedNewsletterMonths, getMonthName } from "@utils/newsletter";
 
 const pipelines = pipelines_json.remote_workflows;
-const advisories = await getCollection("advisories");
-const months = getNewsletterMonths(blogPosts, events, pipelines, advisories);
+const months = await getPublishedNewsletterMonths(getCollection, pipelines);
 
 // Group by year
 const byYear = new Map<number, { year: number; month: number }[]>();

--- a/sites/main-site/src/pages/newsletter/rss.xml.js
+++ b/sites/main-site/src/pages/newsletter/rss.xml.js
@@ -2,7 +2,7 @@ import rss from "@astrojs/rss";
 import { getCollection } from "astro:content";
 import pipelines_json from "@public/pipelines.json";
 import {
-    getNewsletterMonths,
+    getPublishedNewsletterMonths,
     getBlogPostsForMonth,
     getPipelineReleasesForMonth,
     getEventsForMonth,
@@ -20,7 +20,7 @@ export async function GET(context) {
 
     const pipelines = pipelines_json.remote_workflows;
     const advisories = await getCollection("advisories");
-    const months = getNewsletterMonths(blogPosts, events, pipelines, advisories);
+    const months = await getPublishedNewsletterMonths(getCollection, pipelines);
 
     const items = months.map(({ year, month }) => {
         const monthName = getMonthName(month);

--- a/sites/main-site/tests/newsletter.spec.ts
+++ b/sites/main-site/tests/newsletter.spec.ts
@@ -6,6 +6,7 @@ import {
     getBlogPostsForPreviousMonths,
     getPipelineReleasesForMonth,
     getProposalsForMonth,
+    newsletterMonthHasContent,
 } from "@utils/newsletter";
 
 // Unit tests for the newsletter data/date logic. These functions are pure and
@@ -41,6 +42,29 @@ test("getNewsletterMonths dedupes, sorts newest-first, and drops future months",
     // Sorted strictly newest-first.
     const ordinals = months.map((m) => m.year * 12 + m.month);
     expect(ordinals).toEqual([...ordinals].sort((a, b) => b - a));
+});
+
+test("newsletterMonthHasContent gates on the content the newsletter actually renders", () => {
+    // A newsletter dated the 1st of a month looks back at the *previous* calendar
+    // month. A blog post in March 2020 therefore belongs in the April 2020 newsletter,
+    // not March's.
+    const blogPosts = [blog("a", "2020-03-10")];
+
+    // April 2020 shows March's content -> has content.
+    expect(newsletterMonthHasContent(blogPosts, [], [], [], [], 2020, 4)).toBe(true);
+    // March 2020 shows February's content (empty) -> no content.
+    expect(newsletterMonthHasContent(blogPosts, [], [], [], [], 2020, 3)).toBe(false);
+
+    // A lone advisory dated May 2020 surfaces in the June 2020 newsletter, leaving
+    // May's own page empty (the bug behind the orphaned /newsletter/2001/05 page).
+    const advisories = [advisory("adv", "2020-05-25")];
+    expect(newsletterMonthHasContent([], [], [], advisories, [], 2020, 5)).toBe(false);
+    expect(newsletterMonthHasContent([], [], [], advisories, [], 2020, 6)).toBe(true);
+
+    // Upcoming events count for the current and next month's newsletter.
+    const events = [evt("e", "2020-05-20")];
+    expect(newsletterMonthHasContent([], events, [], [], [], 2020, 5)).toBe(true); // event this month
+    expect(newsletterMonthHasContent([], events, [], [], [], 2020, 4)).toBe(true); // event next month
 });
 
 test("getBlogPostsForMonth keeps only that month, newest first", () => {

--- a/sites/main-site/utils/newsletter.ts
+++ b/sites/main-site/utils/newsletter.ts
@@ -149,6 +149,44 @@ export function getNewsletterMonths(
     return months.filter((m) => m.year < currentYear || (m.year === currentYear && m.month <= currentMonth));
 }
 
+/**
+ * Whether the newsletter dated the 1st of (year, month) would render any content.
+ *
+ * The candidate-month set above is seeded from the months that content lands in,
+ * but a newsletter looks *back* at the previous calendar month (blog posts,
+ * advisories, releases, new pipelines, recent events, proposals) and *forward* at
+ * this + next month (upcoming events). That offset means a seeded month can end up
+ * with every section empty — e.g. a lone advisory dated in a month whose preceding
+ * month has nothing. This mirrors the section gating in NewsletterLayout so we only
+ * keep months where at least one section would actually render, and never publish a
+ * page that is just the header and footer.
+ */
+export function newsletterMonthHasContent(
+    blogPosts: { id: string; data: { pubDate: Date } }[],
+    events: { id: string; data: { start: Date } }[],
+    pipelines: PipelineWorkflow[],
+    advisories: { id: string; data: { publishedDate: Date } }[],
+    proposals: RawProposal[],
+    year: number,
+    month: number,
+): boolean {
+    const contentMonth = month === 1 ? 12 : month - 1;
+    const contentYear = month === 1 ? year - 1 : year;
+
+    return (
+        getBlogPostsForMonth(blogPosts, contentYear, contentMonth).length > 0 ||
+        getBlogPostsForPreviousMonths(blogPosts, contentYear, contentMonth, 2).length > 0 ||
+        getAdvisoriesForMonth(advisories, contentYear, contentMonth).length > 0 ||
+        getAdvisoriesForPreviousMonths(advisories, contentYear, contentMonth, 2).length > 0 ||
+        getPipelineReleasesForMonth(pipelines, contentYear, contentMonth).length > 0 ||
+        getNewPipelines(pipelines, contentYear, contentMonth).length > 0 ||
+        getEventsForMonth(events, contentYear, contentMonth).length > 0 ||
+        getEventsForMonth(events, year, month).length > 0 ||
+        getFutureEvents(events, year, month, 1).length > 0 ||
+        getProposalsForMonth(proposals, contentYear, contentMonth).length > 0
+    );
+}
+
 // The blog / events / advisories collections all share the same "filter to a
 // month, sorted by date" and "collect across N adjacent months" shapes. These
 // two generics implement that once; each collection only supplies its date
@@ -425,7 +463,6 @@ export async function getNewsletterStaticPathsData(
     events = events.filter((e: any) => e.id.split("/").length === 2);
 
     const advisories = await getCollectionFn("advisories");
-    const months = getNewsletterMonths(blogPosts, events, pipelines, advisories);
 
     let allProposals: RawProposal[] = [];
     try {
@@ -434,7 +471,25 @@ export async function getNewsletterStaticPathsData(
         console.warn("Could not fetch proposals:", e);
     }
 
+    // Drop any candidate month whose newsletter would render no content (see
+    // newsletterMonthHasContent) so we never publish an empty page.
+    const months = getNewsletterMonths(blogPosts, events, pipelines, advisories).filter((m) =>
+        newsletterMonthHasContent(blogPosts, events, pipelines, advisories, allProposals, m.year, m.month),
+    );
+
     return { months, allProposals };
+}
+
+/**
+ * The canonical list of newsletter months that actually have content, shared by the
+ * listing page and the RSS feed so they stay in lock-step with the generated pages.
+ */
+export async function getPublishedNewsletterMonths(
+    getCollectionFn: (name: string) => Promise<any[]>,
+    pipelines: PipelineWorkflow[],
+): Promise<NewsletterMonth[]> {
+    const { months } = await getNewsletterStaticPathsData(getCollectionFn, pipelines);
+    return months;
 }
 
 /**

--- a/sites/main-site/utils/newsletter.ts
+++ b/sites/main-site/utils/newsletter.ts
@@ -170,21 +170,24 @@ export function newsletterMonthHasContent(
     year: number,
     month: number,
 ): boolean {
-    const contentMonth = month === 1 ? 12 : month - 1;
-    const contentYear = month === 1 ? year - 1 : year;
+    // Previous calendar month, via the date-fns helper so the year boundary is
+    // handled the same way as everywhere else (no manual `month === 1 ? …` maths).
+    const [{ year: contentYear, month: contentMonth }] = adjacentMonths(year, month, 1, -1);
 
-    return (
-        getBlogPostsForMonth(blogPosts, contentYear, contentMonth).length > 0 ||
-        getBlogPostsForPreviousMonths(blogPosts, contentYear, contentMonth, 2).length > 0 ||
-        getAdvisoriesForMonth(advisories, contentYear, contentMonth).length > 0 ||
-        getAdvisoriesForPreviousMonths(advisories, contentYear, contentMonth, 2).length > 0 ||
-        getPipelineReleasesForMonth(pipelines, contentYear, contentMonth).length > 0 ||
-        getNewPipelines(pipelines, contentYear, contentMonth).length > 0 ||
-        getEventsForMonth(events, contentYear, contentMonth).length > 0 ||
-        getEventsForMonth(events, year, month).length > 0 ||
-        getFutureEvents(events, year, month, 1).length > 0 ||
-        getProposalsForMonth(proposals, contentYear, contentMonth).length > 0
-    );
+    const checks = [
+        () => getBlogPostsForMonth(blogPosts, contentYear, contentMonth),
+        () => getBlogPostsForPreviousMonths(blogPosts, contentYear, contentMonth, 2),
+        () => getAdvisoriesForMonth(advisories, contentYear, contentMonth),
+        () => getAdvisoriesForPreviousMonths(advisories, contentYear, contentMonth, 2),
+        () => getPipelineReleasesForMonth(pipelines, contentYear, contentMonth),
+        () => getNewPipelines(pipelines, contentYear, contentMonth),
+        () => getEventsForMonth(events, contentYear, contentMonth),
+        () => getEventsForMonth(events, year, month),
+        () => getFutureEvents(events, year, month, 1),
+        () => getProposalsForMonth(proposals, contentYear, contentMonth),
+    ];
+
+    return checks.some((check) => check().length > 0);
 }
 
 // The blog / events / advisories collections all share the same "filter to a


### PR DESCRIPTION
## Summary
This PR prevents publishing empty newsletter pages by filtering out months that would render no content. Previously, the newsletter could generate pages with only headers and footers when content dates didn't align with the month boundaries used for newsletter generation.

## Key Changes
- **Added `newsletterMonthHasContent()` function**: A new utility that checks whether a newsletter for a given month would have any renderable content by examining all content sections (blog posts, advisories, pipelines, events, proposals) with their respective lookback/lookahead windows.

- **Added `getPublishedNewsletterMonths()` function**: A new public API that returns the canonical list of newsletter months with actual content, ensuring the listing page and RSS feed stay synchronized with generated pages.

- **Updated `getNewsletterStaticPathsData()`**: Now filters candidate months through `newsletterMonthHasContent()` to exclude empty pages before they're generated.

- **Updated newsletter listing page and RSS feed**: Both now use the new `getPublishedNewsletterMonths()` function instead of directly calling `getNewsletterMonths()`, ensuring they only reference months that actually exist.

- **Added comprehensive test coverage**: New test case validates the content gating logic, including edge cases like lone advisories creating orphaned pages and upcoming events spanning month boundaries.

## Implementation Details
The fix accounts for the newsletter's temporal offset: a newsletter dated the 1st of a month looks back at the previous calendar month for most content (blog posts, advisories, releases, pipelines) but forward at the current and next month for upcoming events. This means a month seeded by content can end up empty if that content only appears in the lookback/lookahead windows of adjacent months. The solution mirrors the section gating logic in `NewsletterLayout` to prevent publishing pages with no actual content.

https://claude.ai/code/session_016APe7N3CUvzw8qa1AtLkFv

@netlify /newsletter