### PR TITLE
Add bytesize: nf-core newsletter with Phil Ewels

### DIFF
--- a/sites/main-site/src/content/events/2026/bytesize_newsletter.md
+++ b/sites/main-site/src/content/events/2026/bytesize_newsletter.md
@@ -1,0 +1,17 @@
+---
+title: "Bytesize: nf-core newsletter"
+subtitle: Phil Ewels, Seqera
+type: talk
+startDate: "2026-06-23"
+startTime: "13:00+02:00"
+endDate: "2026-06-23"
+endTime: "13:30+02:00"
+locations:
+  - name: Online
+    links:
+      - https://stockholmuniversity.zoom.us/j/66855293599
+---
+
+This week, Phil Ewels ([@ewels](https://github.com/ewels)) will talk about the new nf-core newsletter.
+The newsletter is a monthly digest of community news, pipeline releases, events and more, delivered to your inbox.
+You can sign up at [nf-co.re/newsletter](/newsletter/subscribe).


### PR DESCRIPTION
Adding bytesize talk page for today's session featuring Phil Ewels introducing the new nf-core newsletter.

@netlify /events/2026/bytesize_newsletter