### PR TITLE
Add bytesize: Parameter typing in Nextflow strict syntax

### DIFF
--- a/sites/main-site/src/content/events/2026/bytesize_parameter_types.md
+++ b/sites/main-site/src/content/events/2026/bytesize_parameter_types.md
@@ -1,0 +1,17 @@
+---
+title: "Bytesize: Parameter typing in Nextflow strict syntax"
+subtitle: Nicolas Vannieuwkerke, Center for Medical Genetics Ghent
+type: talk
+startDate: "2026-06-30"
+startTime: "13:00+02:00"
+endDate: "2026-06-30"
+endTime: "13:30+02:00"
+locations:
+  - name: Online
+    links:
+      - https://stockholmuniversity.zoom.us/j/66855293599
+---
+
+This week, Nicolas ([@nvnieuwk](https://github.com/nvnieuwk)) will talk about parameter typing in Nextflow strict syntax.
+With Nextflow 26.04.0, parameters passed via the CLI are now always strings. This bytesize will cover what changed, how to migrate pipelines to use parameter types, and tips for both users and developers.
+You can read more about this topic in the [blog post](/blog/2026/parameter-types).


### PR DESCRIPTION
Adding bytesize talk page for next week's session featuring Nicolas Vannieuwkerke about parameter typing in Nextflow strict syntax.

@netlify /events/2026/bytesize_parameter_types