### PR TITLE
bytesize: add YouTube link for newsletter talk

### DIFF
--- a/sites/main-site/src/content/events/2026/bytesize_newsletter.md
+++ b/sites/main-site/src/content/events/2026/bytesize_newsletter.md
@@ -6,10 +6,7 @@ startDate: "2026-06-23"
 startTime: "13:00+02:00"
 endDate: "2026-06-23"
 endTime: "13:30+02:00"
-locations:
-  - name: Online
-    links:
-      - https://stockholmuniversity.zoom.us/j/66855293599
+youtubeEmbed: https://youtu.be/xACxeNzWGQ4
 ---
 
 This week, Phil Ewels ([@ewels](https://github.com/ewels)) will talk about the new nf-core newsletter.


### PR DESCRIPTION
Add YouTube recording link for the nf-core newsletter bytesize talk (June 23, 2026).

Changes:
- Added `youtubeEmbed` with link to https://youtu.be/xACxeNzWGQ4
- Removed Zoom meeting link (event has passed)

@netlify /events/2026/bytesize_newsletter