### PR TITLE
bytesize: add longraredisease talk

### DIFF
--- a/sites/main-site/src/content/events/2026/bytesize_longraredisease.md
+++ b/sites/main-site/src/content/events/2026/bytesize_longraredisease.md
@@ -1,0 +1,15 @@
+---
+title: "Bytesize: nf-core/longraredisease"
+subtitle: Nour Mahfel, University of Birmingham
+type: talk
+startDate: "2026-08-18"
+startTime: "13:00+02:00"
+endDate: "2026-08-18"
+endTime: "13:30+02:00"
+locations:
+  - name: Online
+    links:
+      - https://stockholmuniversity.zoom.us/j/66855293599
+---
+
+Nour Mahfel ([@nourmahfel](https://github.com/nourmahfel)) will present [nf-core/longraredisease](https://github.com/nf-core/longraredisease) v1.0.0, a Nextflow pipeline for variant detection and clinical interpretation from long-read sequencing data (ONT/PacBio) for rare disease diagnostics.


### PR DESCRIPTION
Add bytesize page for the nf-core/longraredisease talk by Nour Mahfel on August 18th, 2026.

@netlify /events/2026/bytesize_longraredisease