### PR TITLE
Fix missing space between month and year in newsletter header

### DIFF
--- a/sites/main-site/src/layouts/NewsletterLayout.astro
+++ b/sites/main-site/src/layouts/NewsletterLayout.astro
@@ -185,8 +185,7 @@ const pipelinesAndProposals: { title: string; url: string; sub: string; labels: 
                     style="max-width: 100%; height: auto; display: none; margin: 0 auto;"
                 />
                 <p class="nl-muted" style="margin: 12px 0 0; font-size: 18px; color: #666666;">
-                    1st {monthName}
-                    {year}
+                    1st {monthName} {year}
                 </p>
             </td>
         </tr>

--- a/sites/main-site/src/layouts/NewsletterLayout.astro
+++ b/sites/main-site/src/layouts/NewsletterLayout.astro
@@ -185,7 +185,8 @@ const pipelinesAndProposals: { title: string; url: string; sub: string; labels: 
                     style="max-width: 100%; height: auto; display: none; margin: 0 auto;"
                 />
                 <p class="nl-muted" style="margin: 12px 0 0; font-size: 18px; color: #666666;">
-                    1st {monthName} {year}
+                    1st {monthName}
+                    {" "}{year}
                 </p>
             </td>
         </tr>

--- a/sites/main-site/src/pages/newsletter/index.astro
+++ b/sites/main-site/src/pages/newsletter/index.astro
@@ -35,7 +35,9 @@ const latest = months[0];
                 <a
                     href="https://www.linkedin.com/newsletters/nf-core-7474718981564706816/"
                     target="_blank"
-                    rel="noopener"><i class="fab fa-linkedin me-1"></i>LinkedIn</a
+                    rel="noopener"
+                >
+                    <i class="fab fa-linkedin mx-1"></i>LinkedIn</a
                 >.
             </p>
         </div>
@@ -44,7 +46,7 @@ const latest = months[0];
     {
         latest && (
             <div class="alert alert-success mb-4">
-                <strong>Latest newsletter:</strong>
+                <strong>Latest newsletter: </strong>
                 <a href={`/newsletter/${latest.year}/${String(latest.month).padStart(2, "0")}`}>
                     {getMonthName(latest.month)} {latest.year}
                 </a>


### PR DESCRIPTION
## Problem

The newsletter header date rendered as e.g. **"1st July2026"** — no space between the month name and the year (visible at https://nf-co.re/newsletter/2026/07).

## Cause

In `NewsletterLayout.astro`, `{monthName}` and `{year}` were on separate lines:

```jsx
1st {monthName}
{year}
```

In JSX/Astro, whitespace-only text between two expressions that contains a newline is collapsed to nothing, so the two values ran together: `1st July` + `2026` → `1st July2026`.

## Fix

Put them on a single line with an explicit space:

```jsx
1st {monthName} {year}
```

Now renders correctly as "1st July 2026".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J9yEgk3xrExJerWdMMjNkE)_

@netlify /newsletter