### PR TITLE
Add bytesize page for nf-core/drop

### DIFF
--- a/sites/main-site/src/content/events/2026/bytesize_drop.md
+++ b/sites/main-site/src/content/events/2026/bytesize_drop.md
@@ -1,0 +1,15 @@
+---
+title: "Bytesize: nf-core/drop"
+subtitle: Ata Jadid Ahari, Nicolas Vannieuwkerke
+type: talk
+startDate: "2026-08-25"
+startTime: "13:00+02:00"
+endDate: "2026-08-25"
+endTime: "13:30+02:00"
+locations:
+  - name: Online
+    links:
+      - https://stockholmuniversity.zoom.us/j/66855293599
+---
+
+Ata Jadid Ahari ([@AtaJadidAhari](https://github.com/AtaJadidAhari)) and Nicolas Vannieuwkerke ([@nvnieuwk](https://github.com/nvnieuwk)) will present [nf-core/drop](https://github.com/nf-core/drop) v1.0.0, a Nextflow pipeline for detecting aberrant expression, aberrant splicing, and mono-allelic expression from RNA sequencing data, useful for diagnosis of rare disorders.


### PR DESCRIPTION
Add bytesize page for nf-core/drop presentation on August 25, 2026.

Speakers:
- Ata Jadid Ahari ([@AtaJadidAhari](https://github.com/AtaJadidAhari))
- Nicolas Vannieuwkerke ([@nvnieuwk](https://github.com/nvnieuwk))

---
Generated via opencode.
Verified by @maxulysse 