### PR TITLE
fix(nextflow_version): fail the build instead of publishing an empty payload

### DIFF
--- a/sites/main-site/src/pages/nextflow_version.ts
+++ b/sites/main-site/src/pages/nextflow_version.ts
@@ -3,65 +3,63 @@ import { octokit } from '@components/octokit';
 import type { OctokitResponse } from '@octokit/types';
 
 export const GET: APIRoute = async ({ params, request }) => {
-    try {
-        // get all releases as versions, go through all release pages
-
-        const versions: {}[] = [];
-        let page = 1;
-        let releases: OctokitResponse<any>;
-        do {
-            releases = await octokit.request('GET /repos/{owner}/{repo}/releases', {
-                owner: 'nextflow-io',
-                repo: 'nextflow',
-                page,
-            });
-            versions.push(...releases.data);
-            page++;
-        } while (releases.headers.link?.includes('rel="next"'));
-
-        const formattedVersions = versions.map((version: any) => ({
-            version: version['tag_name'],
-            isEdge: version['prerelease'],
-            downloadUrl: version['assets'][0] && version['assets'][0]['browser_download_url'],
-            downloadUrlAll: version['assets'][1] && version['assets'][1]['browser_download_url'],
-            published_at: version['published_at'],
-        })).sort((a: any, b: any) => { // sort version by version number, by removing "-edge" suffices and then comparing semver
-            const aVersion = a['version'].replace('-edge', '').replace('v', '');
-            const bVersion = b['version'].replace('-edge', '').replace('v', '');
-            // check first major, then minor, then patch
-            const aVersionSplit = aVersion.split('.');
-            const bVersionSplit = bVersion.split('.');
-            for (let i = 0; i < 3; i++) {
-                if (parseInt(aVersionSplit[i]) > parseInt(bVersionSplit[i])) {
-                    return -1;
-                } else if (parseInt(aVersionSplit[i]) < parseInt(bVersionSplit[i])) {
-                    return 1;
-                }
-            }
-            return 0;
+    // get all releases as versions, go through all release pages
+    const versions: {}[] = [];
+    let page = 1;
+    let releases: OctokitResponse<any>;
+    do {
+        releases = await octokit.request('GET /repos/{owner}/{repo}/releases', {
+            owner: 'nextflow-io',
+            repo: 'nextflow',
+            page,
         });
+        versions.push(...releases.data);
+        page++;
+    } while (releases.headers.link?.includes('rel="next"'));
 
-        return new Response(
-            JSON.stringify({
-                latest:{
-                    stable: formattedVersions.find((version: any) => !version.isEdge),
-                    edge: formattedVersions.find((version: any) => version.isEdge),
-                    everything: formattedVersions[0],
-                },
-                versions: formattedVersions,
-            }), {
-        status: 200,
-        headers: {
-        "Content-Type": "application/json"
+    const formattedVersions = versions.map((version: any) => ({
+        version: version['tag_name'],
+        isEdge: version['prerelease'],
+        downloadUrl: version['assets'][0] && version['assets'][0]['browser_download_url'],
+        downloadUrlAll: version['assets'][1] && version['assets'][1]['browser_download_url'],
+        published_at: version['published_at'],
+    })).sort((a: any, b: any) => { // sort version by version number, by removing "-edge" suffices and then comparing semver
+        const aVersion = a['version'].replace('-edge', '').replace('v', '');
+        const bVersion = b['version'].replace('-edge', '').replace('v', '');
+        // check first major, then minor, then patch
+        const aVersionSplit = aVersion.split('.');
+        const bVersionSplit = bVersion.split('.');
+        for (let i = 0; i < 3; i++) {
+            if (parseInt(aVersionSplit[i]) > parseInt(bVersionSplit[i])) {
+                return -1;
+            } else if (parseInt(aVersionSplit[i]) < parseInt(bVersionSplit[i])) {
+                return 1;
+            }
         }
-    }
+        return 0;
+    });
+
+    // Fail if no data. setup-nextflow action depends on this file.
+    if (formattedVersions.length === 0) {
+        throw new Error(
+            'nextflow_version: GitHub returned no Nextflow releases; refusing to build an empty payload.',
         );
-    } catch (error) {
-        return new Response(
-            JSON.stringify({
-                error: error.message,
-            }),
-            { status: 500 },
-        );
     }
+
+    return new Response(
+        JSON.stringify({
+            latest: {
+                stable: formattedVersions.find((version: any) => !version.isEdge),
+                edge: formattedVersions.find((version: any) => version.isEdge),
+                everything: formattedVersions[0],
+            },
+            versions: formattedVersions,
+        }),
+        {
+            status: 200,
+            headers: {
+                "Content-Type": "application/json",
+            },
+        },
+    );
 };

--- a/sites/main-site/src/pages/nextflow_version.ts
+++ b/sites/main-site/src/pages/nextflow_version.ts
@@ -1,56 +1,43 @@
-import type { APIRoute } from 'astro';
-import { octokit } from '@components/octokit';
-import type { OctokitResponse } from '@octokit/types';
+import type { APIRoute } from "astro";
+import { octokit } from "@components/octokit";
 
-export const GET: APIRoute = async ({ params, request }) => {
-    // get all releases as versions, go through all release pages
-    const versions: {}[] = [];
-    let page = 1;
-    let releases: OctokitResponse<any>;
-    do {
-        releases = await octokit.request('GET /repos/{owner}/{repo}/releases', {
-            owner: 'nextflow-io',
-            repo: 'nextflow',
-            page,
-        });
-        versions.push(...releases.data);
-        page++;
-    } while (releases.headers.link?.includes('rel="next"'));
-
-    const formattedVersions = versions.map((version: any) => ({
-        version: version['tag_name'],
-        isEdge: version['prerelease'],
-        downloadUrl: version['assets'][0] && version['assets'][0]['browser_download_url'],
-        downloadUrlAll: version['assets'][1] && version['assets'][1]['browser_download_url'],
-        published_at: version['published_at'],
-    })).sort((a: any, b: any) => { // sort version by version number, by removing "-edge" suffices and then comparing semver
-        const aVersion = a['version'].replace('-edge', '').replace('v', '');
-        const bVersion = b['version'].replace('-edge', '').replace('v', '');
-        // check first major, then minor, then patch
-        const aVersionSplit = aVersion.split('.');
-        const bVersionSplit = bVersion.split('.');
-        for (let i = 0; i < 3; i++) {
-            if (parseInt(aVersionSplit[i]) > parseInt(bVersionSplit[i])) {
-                return -1;
-            } else if (parseInt(aVersionSplit[i]) < parseInt(bVersionSplit[i])) {
-                return 1;
-            }
-        }
-        return 0;
+export const GET: APIRoute = async () => {
+    const versions = await octokit.paginate(octokit.rest.repos.listReleases, {
+        owner: "nextflow-io",
+        repo: "nextflow",
+        per_page: 100,
     });
+
+    const formattedVersions = versions
+        .map((version) => ({
+            version: version.tag_name,
+            isEdge: version.prerelease,
+            downloadUrl: version.assets[0]?.browser_download_url,
+            downloadUrlAll: version.assets[1]?.browser_download_url,
+            published_at: version.published_at,
+        }))
+        .sort((a, b) => {
+            // remove `-edge` suffixes and then sort by nextflow's date-based versioning
+            const aParts = a.version.replace("-edge", "").replace("v", "").split(".").map(Number);
+            const bParts = b.version.replace("-edge", "").replace("v", "").split(".").map(Number);
+            for (let i = 0; i < 3; i++) {
+                if (aParts[i] !== bParts[i]) {
+                    return bParts[i] - aParts[i];
+                }
+            }
+            return 0;
+        });
 
     // Fail if no data. setup-nextflow action depends on this file.
     if (formattedVersions.length === 0) {
-        throw new Error(
-            'nextflow_version: GitHub returned no Nextflow releases; refusing to build an empty payload.',
-        );
+        throw new Error("nextflow_version: GitHub returned no Nextflow versions; refusing to build an empty payload.");
     }
 
     return new Response(
         JSON.stringify({
             latest: {
-                stable: formattedVersions.find((version: any) => !version.isEdge),
-                edge: formattedVersions.find((version: any) => version.isEdge),
+                stable: formattedVersions.find((version) => !version.isEdge),
+                edge: formattedVersions.find((version) => version.isEdge),
                 everything: formattedVersions[0],
             },
             versions: formattedVersions,


### PR DESCRIPTION
The /nextflow_version endpoint is prerendered to a static file at build
time and consumed by external tooling (e.g. nf-core/setup-nextflow) that
resolves latest-* aliases from it. When the GitHub releases API was
degraded during a build, it returned no releases and the empty payload
{"latest":{},"versions":[]} got baked into the site, breaking every
downstream consumer until the next deploy (issues #3462, #4317).

Keep the endpoint prerendered (it gets heavy traffic and rarely changes),
but throw when the release list comes back empty so the build aborts and
the last successful deploy is retained rather than overwritten with a
broken one. Dropping the try/catch also lets a failed GitHub fetch
propagate and fail the build for the same reason.

Closes #4317
Closes #3462

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GoH7JeNdRpLFQhA8WMovWG

@netlify /nextflow_version.ts