### PR TITLE
Link to latest stable release from dev version warning

### DIFF
--- a/sites/main-site/src/components/header/SubHeader.astro
+++ b/sites/main-site/src/components/header/SubHeader.astro
@@ -27,6 +27,8 @@ let latest_link = "";
 if (pipeline.length > 0) {
     latest_link = Astro.url.pathname.replace(pipeline + "/" + version, pipeline + "/" + latestVersion);
 }
+const hasStableRelease = latestVersion.length > 0 && latestVersion !== "dev";
+const latestVersionLabel = latestVersion.trim().startsWith("v") ? latestVersion.trim() : "v" + latestVersion.trim();
 let component_name = component;
 if (component_type === "modules" && component) {
     component_name = component.replace("_", "/");
@@ -42,7 +44,15 @@ const shaking = version === "dev" ? "3deg" : "1deg";
                 <div class="alert alert-warning p-1 p-md-3" role="alert">
                     <span>
                         {version === "dev" ? (
-                            <span>This is the development version of the pipeline.</span>
+                            <span>
+                                This is the development version of the pipeline.
+                                {hasStableRelease && (
+                                    <>
+                                        {" "}
+                                        <a href={latest_link}>View the latest {latestVersionLabel} release.</a>
+                                    </>
+                                )}
+                            </span>
                         ) : (
                             <span>
                                 These pages are for an old version of the pipeline (<code>{version}</code>). The latest

--- a/sites/main-site/src/components/header/SubHeader.astro
+++ b/sites/main-site/src/components/header/SubHeader.astro
@@ -47,7 +47,7 @@ const shaking = version === "dev" ? "3deg" : "1deg";
                                 {latestVersion !== "dev" && (
                                     <>
                                         {" "}
-                                        <a href={latest_link}>View the latest v{latestVersion.trim()} release.</a>
+                                        <a href={latest_link}>View the latest v{latestVersion} release.</a>
                                     </>
                                 )}
                             </span>

--- a/sites/main-site/src/components/header/SubHeader.astro
+++ b/sites/main-site/src/components/header/SubHeader.astro
@@ -27,8 +27,6 @@ let latest_link = "";
 if (pipeline.length > 0) {
     latest_link = Astro.url.pathname.replace(pipeline + "/" + version, pipeline + "/" + latestVersion);
 }
-const hasStableRelease = latestVersion.length > 0 && latestVersion !== "dev";
-const latestVersionLabel = latestVersion.trim().startsWith("v") ? latestVersion.trim() : "v" + latestVersion.trim();
 let component_name = component;
 if (component_type === "modules" && component) {
     component_name = component.replace("_", "/");
@@ -46,10 +44,10 @@ const shaking = version === "dev" ? "3deg" : "1deg";
                         {version === "dev" ? (
                             <span>
                                 This is the development version of the pipeline.
-                                {hasStableRelease && (
+                                {latestVersion !== "dev" && (
                                     <>
                                         {" "}
-                                        <a href={latest_link}>View the latest {latestVersionLabel} release.</a>
+                                        <a href={latest_link}>View the latest v{latestVersion.trim()} release.</a>
                                     </>
                                 )}
                             </span>


### PR DESCRIPTION
The pipeline development-version warning now links to the latest stable release, naming its version number, when one exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6nozy4rG4YJxdmHhQ3HzF

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6nozy4rG4YJxdmHhQ3HzF)_