### PR TITLE
Harden fix-linting, build-json-files, and add-netlify-link workflows

### DIFF
--- a/.github/workflows/add-netlify-link.yml
+++ b/.github/workflows/add-netlify-link.yml
@@ -6,22 +6,27 @@ on:
       - "sites/**/src/pages/**"
       - "sites/**/src/content/**"
 
+permissions:
+  pull-requests: write
+
 jobs:
   add-comment:
     runs-on: ubuntu-latest
     steps:
-      - name: Check for changed files
-        id: changed-files
-        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
-
       - name: Add Netlify link to PR
-        if: steps.changed-files.outputs.all_changed_files != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
-          github-token: ${{ secrets.NF_CORE_BOT_AUTH_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
-            let changedFiles = `${{ steps.changed-files.outputs.all_changed_files }}`.split(' ').slice(0, 50);
-            console.log('Changed files:', changedFiles)
+            const changedFiles = (await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            }))
+              .map(file => file.filename)
+              .slice(0, 50);
+            console.log('Changed files:', changedFiles);
 
             // remove the sites/** prefix until src
             const processedFiles = changedFiles.map(file => file.replace(/^sites\/[^/]+\//, ''));

--- a/.github/workflows/build-json-files.yml
+++ b/.github/workflows/build-json-files.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.pipeline_name || github.event.client_payload.pipeline_name || 'all' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-component-json:
     runs-on: ubuntu-latest
@@ -27,7 +30,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0 # Don't do a shallow clone
-          token: ${{secrets.NF_CORE_BOT_AUTH_TOKEN}} # Needed for pushing back to the repo
+          persist-credentials: false
 
       # install npm dependencies
       - name: Set up node.js
@@ -39,21 +42,40 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Resolve pipeline name
+        id: pipeline
+        env:
+          PIPELINE_NAME_INPUT: ${{ github.event.inputs.pipeline_name || github.event.client_payload.pipeline_name || '' }}
+        run: |
+          if [ -n "$PIPELINE_NAME_INPUT" ] && [[ ! "$PIPELINE_NAME_INPUT" =~ ^[a-z]+$ ]]; then
+            echo "Invalid pipeline name. Use lowercase letters only, or leave the value empty."
+            exit 1
+          fi
+          echo "pipeline_name=$PIPELINE_NAME_INPUT" >> "$GITHUB_OUTPUT"
+
       - name: create pipeline.json
-        run: npm run build-pipeline-json -- ${{ github.event.inputs.pipeline_name || github.event.client_payload.pipeline_name || '' }}
+        run: npm run build-pipeline-json -- "$PIPELINE_NAME"
         env:
           GITHUB_TOKEN: ${{ secrets.PIPLINE_JSON_BUILD_TOKEN }}
+          PIPELINE_NAME: ${{ steps.pipeline.outputs.pipeline_name }}
 
       - name: create component.json
-        run: npm run build-component-json -- ${{ github.event.inputs.pipeline_name || github.event.client_payload.pipeline_name || '' }}
+        run: npm run build-component-json -- "$PIPELINE_NAME"
         env:
           GITHUB_TOKEN: ${{ secrets.PIPLINE_JSON_BUILD_TOKEN }}
+          PIPELINE_NAME: ${{ steps.pipeline.outputs.pipeline_name }}
 
       - name: Commit and push changes
+        env:
+          GH_TOKEN: ${{ secrets.NF_CORE_BOT_AUTH_TOKEN }}
         run: |
+          gh auth setup-git
           git config user.email "core@nf-co.re"
           git config user.name "nf-core-bot"
           git config push.default upstream
           git status
-          git pull
-          git diff --quiet || (git commit -am "[automated] Update json files" && git push)
+          git -c core.hooksPath=/dev/null pull --ff-only
+          if ! git diff --quiet; then
+            git -c core.hooksPath=/dev/null -c commit.gpgsign=false commit -am "[automated] Update json files"
+            git -c core.hooksPath=/dev/null push
+          fi

--- a/.github/workflows/fix-linting.yml
+++ b/.github/workflows/fix-linting.yml
@@ -3,114 +3,160 @@ on:
   issue_comment:
     types: [created]
 
+permissions: {}
+
 jobs:
-  deploy:
-    # Only run if comment is on a PR with the main repo, and if it contains the magic keywords
+  prepare-fix:
     if: >
       contains(github.event.comment.html_url, '/pull/') &&
       contains(github.event.comment.body, '@nf-core-bot fix linting') &&
       github.repository == 'nf-core/website'
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
     runs-on: ubuntu-latest
+    outputs:
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+      has_patch: ${{ steps.patch.outputs.has_patch }}
+      prek_outcome: ${{ steps.prek.outcome }}
     steps:
-      # Get PR details first
-      - name: Get PR details
-        id: pr
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          script: |
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-            return {
-              head_ref: pr.data.head.ref,
-              head_repo: pr.data.head.repo.full_name
-            };
-
-      # Checkout using default GITHUB_TOKEN (read-only for untrusted code)
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: ${{ fromJSON(steps.pr.outputs.result).head_repo }}
-          ref: ${{ fromJSON(steps.pr.outputs.result).head_ref }}
-          # Don't use bot token here - only default GITHUB_TOKEN
-
-      # indication that the linting is being fixed
       - name: React on comment
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           comment-id: ${{ github.event.comment.id }}
           reactions: eyes
 
-      # Install and run prek
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Checkout pull request
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh pr checkout "$PR_NUMBER"
+          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           cache: npm
 
-      # Use npm ci with --ignore-scripts to prevent arbitrary code execution
-      - run: npm ci --ignore-scripts
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
 
       - name: Run prek
         id: prek
         uses: j178/prek-action@5337cb91e0fa35a7ff31b9ca345126d8bbbcdf16 # v2
         continue-on-error: true
 
-      # indication that the linting has finished
-      - name: react if linting finished successfully
-        if: steps.prek.outcome == 'success'
+      - name: Create lint fix patch
+        id: patch
+        if: steps.prek.outcome == 'failure'
+        run: |
+          git add --all
+          git diff --cached --binary --full-index --no-ext-diff > "${RUNNER_TEMP}/lint-fix.patch"
+          if [ ! -s "${RUNNER_TEMP}/lint-fix.patch" ]; then
+            echo "Prek failed without producing a fix."
+            exit 1
+          fi
+          echo "has_patch=true" >> "$GITHUB_OUTPUT"
+
+      - name: Upload lint fix patch
+        if: steps.patch.outputs.has_patch == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: lint-fix
+          path: ${{ runner.temp }}/lint-fix.patch
+          if-no-files-found: error
+          retention-days: 1
+
+  push-fix:
+    needs: prepare-fix
+    if: ${{ always() && needs.prepare-fix.result != 'skipped' }}
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        if: needs.prepare-fix.outputs.has_patch == 'true'
+        with:
+          persist-credentials: false
+
+      - name: Checkout exact pull request head
+        if: needs.prepare-fix.outputs.has_patch == 'true'
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.prepare-fix.outputs.head_sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh pr checkout "$PR_NUMBER"
+          if [ "$(git rev-parse HEAD)" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "Pull request head changed after linting completed."
+            exit 1
+          fi
+
+      - name: Download lint fix patch
+        if: needs.prepare-fix.outputs.has_patch == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: lint-fix
+          path: ${{ runner.temp }}/lint-fix
+
+      - name: Apply lint fix patch
+        if: needs.prepare-fix.outputs.has_patch == 'true'
+        env:
+          PATCH_FILE: ${{ runner.temp }}/lint-fix/lint-fix.patch
+        run: |
+          if [ ! -f "$PATCH_FILE" ] || [ -L "$PATCH_FILE" ]; then
+            echo "The lint fix artifact does not contain a regular patch file."
+            exit 1
+          fi
+          git apply --index "$PATCH_FILE"
+
+      - name: Commit and push changes
+        id: commit-and-push
+        if: needs.prepare-fix.outputs.has_patch == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.nf_core_bot_auth_token }}
+        run: |
+          gh auth setup-git
+          git config user.email "core@nf-co.re"
+          git config user.name "nf-core-bot"
+          git config push.default upstream
+          git status
+          git -c core.hooksPath=/dev/null -c commit.gpgsign=false commit -m "[automated] Fix code linting"
+          git -c core.hooksPath=/dev/null push
+
+      - name: React if linting finished successfully
+        if: needs.prepare-fix.outputs.prek_outcome == 'success'
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           comment-id: ${{ github.event.comment.id }}
           reactions: "+1"
 
-      # Re-checkout with bot token to push changes
-      - name: Checkout with bot token
-        if: steps.prek.outcome == 'failure'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: ${{ fromJSON(steps.pr.outputs.result).head_repo }}
-          ref: ${{ fromJSON(steps.pr.outputs.result).head_ref }}
-          token: ${{ secrets.nf_core_bot_auth_token }}
-
-      # Re-run prek to apply fixes (idempotent operation)
-      - run: npm ci --ignore-scripts
-      - name: Re-run prek to apply fixes
-        if: steps.prek.outcome == 'failure'
-        uses: j178/prek-action@5337cb91e0fa35a7ff31b9ca345126d8bbbcdf16 # v2
-        continue-on-error: true
-
-      - name: Commit & push changes
-        id: commit-and-push
-        if: steps.prek.outcome == 'failure'
-        run: |
-          git config user.email "core@nf-co.re"
-          git config user.name "nf-core-bot"
-          git add .
-          git status
-          git diff --cached --exit-code || git commit -m "[automated] Fix code linting"
-          git push
-
-      - name: react if linting errors were fixed
-        id: react-if-fixed
+      - name: React if linting errors were fixed
         if: steps.commit-and-push.outcome == 'success'
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           comment-id: ${{ github.event.comment.id }}
           reactions: hooray
 
-      - name: react if linting errors were not fixed
-        if: steps.commit-and-push.outcome == 'failure'
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
-        with:
-          comment-id: ${{ github.event.comment.id }}
-          reactions: confused
-
-      - name: Comment if push failed
-        if: steps.commit-and-push.outcome == 'failure'
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
-        with:
-          issue-number: ${{ github.event.issue.number }}
-          body: |
-            @${{ github.actor }} I tried to fix the linting errors, but it didn't work. Please fix them manually.
-            See [CI log](https://github.com/nf-core/website/actions/runs/${{ github.run_id }}) for more details.
+      - name: Report failure
+        if: ${{ always() && (failure() || needs.prepare-fix.result != 'success') }}
+        env:
+          ACTOR: ${{ github.actor }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" -f content="confused"
+          gh pr comment "$PR_NUMBER" --body "@${ACTOR} I tried to fix the linting errors, but it didn't work. Please fix them manually.
+          See [CI log](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) for more details."


### PR DESCRIPTION
A security review flagged that the comment-triggered lint-fix workflow re-checked out a pull request with the bot PAT and re-ran `prek` (PR-controlled pre-commit hooks) while that credential was live, letting PR-authored hook config read the token. It also flagged default write-scoped workflow tokens, PR filenames interpolated directly into JavaScript source, and an unvalidated `repository_dispatch`/`workflow_dispatch` input reaching a shell command.

<details>
- **fix-linting.yml**: split into an unprivileged job that checks out the PR and runs `prek` with no bot PAT, uploading a patch artifact, and a privileged job that verifies the PR head hasn't moved, applies the patch, and pushes with the PAT scoped to only that step.
- **build-json-files.yml**: validate `pipeline_name` against the repository's lowercase-only naming rule and pass it through an environment variable instead of interpolating it into the run command; scope the bot PAT to the commit-and-push step only.
- **add-netlify-link.yml**: drop the bot PAT and the `tj-actions/changed-files` dependency; fetch PR filenames via the Octokit client inside the trusted script instead of interpolating them into JavaScript source.
- Explicit minimal `permissions:` on all three workflows instead of relying on the repository's default write-scoped token.

## Test plan
- [x] `zizmor` on all three workflows: clean except the expected/inherent `pull_request_target`-trigger warning on `add-netlify-link.yml` (mitigated: no code checkout, `pull-requests: write` only, PR data fetched via API inside the trusted script rather than interpolated into it)
- [x] YAML parses correctly (validated via zizmor's parse step)
- [x] Manually traced permission scopes for every `gh`/API call in the new jobs
- [x] Verified experimentally that `git apply --index` is all-or-nothing (no partial apply), so no separate `--check` pass is needed
- [x] Confirmed all 143 current pipeline names match the `^[a-z]+$` validation added to `build-json-files.yml`
- [ ] Exercise `fix-linting.yml` end-to-end on a real PR comment once merged (can't be tested locally)

</details>