### PR TITLE
Hide the Turnstile widget unless interaction is needed

### DIFF
--- a/sites/main-site/src/components/newsletter/NewsletterSignup.astro
+++ b/sites/main-site/src/components/newsletter/NewsletterSignup.astro
@@ -62,12 +62,18 @@ const TURNSTILE_SITE_KEY = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
 
 {
     TURNSTILE_SITE_KEY && (
-        <script
-            is:inline
-            src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onloadTurnstileCallback&render=explicit"
-            async
-            defer
-        />
+        <Fragment>
+            {/* Stub so api.js finds a callback on load, silencing a console warning —
+                the deferred module below can't win that race. It replaces this with the
+                real renderer, and renders any widget already in the DOM. */}
+            <script is:inline>{"window.onloadTurnstileCallback = function () {};"}</script>
+            <script
+                is:inline
+                src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onloadTurnstileCallback&render=explicit"
+                async
+                defer
+            />
+        </Fragment>
     )
 }
 
@@ -88,6 +94,10 @@ const TURNSTILE_SITE_KEY = import.meta.env.PUBLIC_TURNSTILE_SITE_KEY;
             const button = form.querySelector('button[type="submit"]') as HTMLButtonElement;
             turnstile.render(container, {
                 sitekey: container.dataset.sitekey,
+                // Hidden unless the visitor actually has to solve something. Note this
+                // needs a Managed widget: an Invisible one is never shown, so anyone it
+                // can't clear silently (VPN, Tor, locked-down browser) would be stuck.
+                appearance: "interaction-only",
                 callback: (token: string) => {
                     form.dataset.turnstileToken = token;
                     button.disabled = false;


### PR DESCRIPTION
Two small follow-ups to the Turnstile sign-up widget.

## Hide the widget unless a challenge is needed

The always-visible widget is intrusive where the form is a small inline element — the homepage, `/newsletter`, and the newsletter launch blog post. Setting `appearance: "interaction-only"` keeps it hidden for visitors who pass silently and shows the challenge only to those who actually have to solve one.

Deliberately **not** switching the Cloudflare widget to Invisible mode. Per Cloudflare's docs an invisible widget is never shown regardless of appearance settings, so a visitor it cannot clear silently — on a VPN, over Tor, or with a locked-down browser — gets no challenge to complete and simply cannot subscribe, with nothing on screen to explain why. A fair number of nf-core users are exactly those people. `interaction-only` on the existing Managed widget gets the clean look without the dead end, and needs no dashboard change or new site key.

## Declare the onload callback before api.js

Turnstile logged this on every page view:

```
[Cloudflare Turnstile] Unable to find onload callback 'onloadTurnstileCallback'
immediately after loading, expected 'function', got 'undefined'.
```

`api.js` is an `is:inline` script, but the callback was assigned inside a bare Astro `<script>`, which is emitted as `type="module"` and therefore deferred — so it cannot win that race. A stub declared ahead of `api.js` fixes it, and the module still overwrites the stub with the real renderer.

This is cosmetic. The widget rendered correctly either way, because the module also renders any widget already in the DOM, so both load orders were already covered. It only removes console noise.

## Verification

Full production build with a Cloudflare test site key. Confirmed in the generated HTML that the stub precedes `api.js`, and that `interaction-only` reaches all four pages that embed the component — homepage, `/newsletter`, `/newsletter/subscribe`, and `blog/2026/newsletter-launch`.

Playwright still cannot run in this repo (`Failed to resolve "extends" path "astro/tsconfigs/base"`), which is pre-existing on `main` and unrelated — the fixes for it are sitting in another unmerged branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSUGrKz9VzGoe4S1Hr9soj
