### PR TITLE
Point Renovate at the public org preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
     $schema: "https://docs.renovatebot.com/renovate-schema.json",
     extends: [
-        "github>nf-core/ops//.github/renovate/default.json5",
+        "local>nf-core/.github:renovate-config",
         "config:recommended",
         "schedule:monthly",
     ],


### PR DESCRIPTION
Repoints this repo's Renovate config at the shared preset's new home.

The preset used to live in `nf-core/ops`, referenced as
`github>nf-core/ops//.github/renovate/default.json5`. `nf-core/ops` is private,
so once it went private that reference stopped resolving for public repos,
Renovate treated it as a config error, and dependency PRs stopped across the
org — see https://github.com/nf-core/tools/issues/4446.

The preset now lives in the public `nf-core/.github` repo, which is also the
location Renovate probes by convention for org-level presets. Only the
`extends` line changes here; this repo's own overrides are untouched.

Verification that the new reference is publicly readable while the old one is not:

```console
$ curl -so /dev/null -w '%{http_code}\n' https://raw.githubusercontent.com/nf-core/.github/master/renovate-config.json
200
$ curl -so /dev/null -w '%{http_code}\n' https://raw.githubusercontent.com/nf-core/ops/main/.github/renovate/default.json5
404
```

Context: https://github.com/nf-core/.github/pull/5 and https://github.com/nf-core/ops/pull/214
