### PR TITLE
Add YouTube link and embedAt for longraredisease bytesize

### DIFF
--- a/sites/main-site/src/content/events/2026/bytesize_longraredisease.md
+++ b/sites/main-site/src/content/events/2026/bytesize_longraredisease.md
@@ -6,6 +6,8 @@ startDate: "2026-08-18"
 startTime: "13:00+02:00"
 endDate: "2026-08-18"
 endTime: "13:30+02:00"
+embedAt: "longraredisease"
+youtubeEmbed: https://youtu.be/A7cMeOJ6TIA
 locations:
   - name: Online
     links:

--- a/sites/main-site/src/content/events/2026/bytesize_longraredisease.md
+++ b/sites/main-site/src/content/events/2026/bytesize_longraredisease.md
@@ -11,7 +11,7 @@ youtubeEmbed: https://youtu.be/A7cMeOJ6TIA
 locations:
   - name: Online
     links:
-      - https://stockholmuniversity.zoom.us/j/66855293599
+      - https://youtu.be/A7cMeOJ6TIA
 ---
 
 Nour Mahfel ([@nourmahfel](https://github.com/nourmahfel)) will present [nf-core/longraredisease](https://github.com/nf-core/longraredisease) v1.0.0, a Nextflow pipeline for variant detection and clinical interpretation from long-read sequencing data (ONT/PacBio) for rare disease diagnostics.


### PR DESCRIPTION
Add YouTube link and embedAt for the nf-core/longraredisease bytesize talk.

@netlify /events/2026/bytesize_longraredisease