### PR TITLE
Add Benchmarking hackathon project for Barcelona 2026

### DIFF
--- a/sites/main-site/src/content/hackathon-projects/hackathon-barcelona-2026/benchmarking.md
+++ b/sites/main-site/src/content/hackathon-projects/hackathon-barcelona-2026/benchmarking.md
@@ -1,0 +1,20 @@
+---
+title: Benchmarking
+category: special-interest-groups
+slack: https://nfcore.slack.com/archives/C066SFL4PL4
+location: Barcelona
+leaders:
+  kubranarci:
+    name: Kübra Narcı
+    slack: https://nfcore.slack.com/team/U03EY2LC5V3
+---
+
+## Goal
+
+Community building and engagement, educational content creation, technical performance tracking, modularizing benchmarking components, and working on nf-core/variantbenchmarking.
+
+## Description
+
+The Benchmarking Special Interest Group provides a centralized home within nf-core for performance and accuracy testing across all bioinformatics workflows. While initiated by the development of the nf-core/variantbenchmarking pipeline, this group expands the scope to include any type of method comparison, validation, or resource efficiency study.
+
+Check for more here: https://nf-co.re/special-interest-groups/benchmarking


### PR DESCRIPTION
Adds the **Benchmarking** project (Special Interest Groups) for the October 2026 Barcelona hackathon, submitted by @kubranarci.

The Benchmarking Special Interest Group provides a centralized home within nf-core for performance and accuracy testing across all bioinformatics workflows, including work on nf-core/variantbenchmarking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@netlify /hackathon-projects/hackathon-barcelona-2026/benchmarking