### PR TITLE
Add nf-core/genomeqc preprint to publications

### DIFF
--- a/sites/main-site/src/content/about/publications.mdx
+++ b/sites/main-site/src/content/about/publications.mdx
@@ -219,6 +219,18 @@ Maxime U. Garcia, Judith Neukamm, Alexander Peltzer
 doi: [10.7717/peerj.10947](https://doi.org/10.7717/peerj.10947)
 :::
 
+### [nf-core/genomeqc](https://nf-co.re/genomeqc)
+
+:::tip{.fa-newspaper title="nf-core/genomeqc: a best-practice pipeline for comparing genome and assembly quality"}
+
+<Altmetric doi="10.64898/2026.08.20.745971" />
+Christopher Douglas Robert Wyatt, Fernando Duarte Frutos, Stephen D Turner, Alexandra Cerqueira De Araujo, Usman
+Rashid, Victoria Begley, Seirian Sumner
+
+[_bioRxiv_ 2026.08.20.745971](https://www.biorxiv.org/content/10.64898/2026.08.20.745971v1);
+doi: [10.64898/2026.08.20.745971](https://doi.org/10.64898/2026.08.20.745971)
+:::
+
 ### [nf-core/hgtseq](https://nf-co.re/hgtseq)
 
 :::tip{.fa-newspaper title="hgtseq: A Standard Pipeline to Study Horizontal Gene Transfer"}

--- a/sites/main-site/src/content/about/publications.mdx
+++ b/sites/main-site/src/content/about/publications.mdx
@@ -224,8 +224,8 @@ doi: [10.7717/peerj.10947](https://doi.org/10.7717/peerj.10947)
 :::tip{.fa-newspaper title="nf-core/genomeqc: a best-practice pipeline for comparing genome and assembly quality"}
 
 <Altmetric doi="10.64898/2026.08.20.745971" />
-Christopher Douglas Robert Wyatt, Fernando Duarte Frutos, Stephen D Turner, Alexandra Cerqueira De Araujo, Usman
-Rashid, Victoria Begley, Seirian Sumner
+Christopher Douglas Robert Wyatt, Fernando Duarte Frutos, Stephen D Turner, Alexandra Cerqueira De Araujo, Usman Rashid,
+Victoria Begley, Seirian Sumner
 
 [_bioRxiv_ 2026.08.20.745971](https://www.biorxiv.org/content/10.64898/2026.08.20.745971v1);
 doi: [10.64898/2026.08.20.745971](https://doi.org/10.64898/2026.08.20.745971)


### PR DESCRIPTION
## Summary
- Adds the bioRxiv preprint for `nf-core/genomeqc` to the [publications page](https://github.com/nf-core/website/blob/main/sites/main-site/src/content/about/publications.mdx), following the existing format and alphabetical ordering.
- Title: "nf-core/genomeqc: a best-practice pipeline for comparing genome and assembly quality"
- DOI: [10.64898/2026.08.20.745971](https://doi.org/10.64898/2026.08.20.745971)

Marked as WIP/draft while I double-check formatting — will mark ready for review shortly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@netlify /about/publications