### PR TITLE
Add groupBy prop to hackathon project list

### DIFF
--- a/sites/main-site/src/components/event/HackathonProjects/ListProjects.astro
+++ b/sites/main-site/src/components/event/HackathonProjects/ListProjects.astro
@@ -2,11 +2,12 @@
 import Project from "@components/event/HackathonProjects/Project.astro";
 import { getCollection } from "astro:content";
 
-const { eventPath, showCount = false } = Astro.props;
+const { eventPath, showCount = false, groupBy = "location" } = Astro.props;
 
 export interface Props {
     eventPath?: string;
     showCount?: boolean;
+    groupBy?: "location" | "category";
 }
 
 let projects = await getCollection("hackathon-projects");
@@ -24,25 +25,23 @@ projects = projects.map((project) => ({
     },
 }));
 
-// sort projects by data.location and then data.category
-projects.sort((a, b) => {
-    return (
-        (a.data.location ?? "").localeCompare(b.data.location ?? "") || a.data.category.localeCompare(b.data.category)
-    );
+const groupOf = (project) => (groupBy === "category" ? project.data.category : (project.data.location ?? ""));
+
+const groups = [...new Set(projects.map(groupOf))].sort((a, b) => {
+    // sort "online" to the top
+    if (groupBy === "location") {
+        if (a === "online") return -1;
+        if (b === "online") return 1;
+    }
+    return a.localeCompare(b);
 });
 
-const locations = [...new Set(projects.map((project) => project.data.location))];
-// sort "online" to the top
-locations?.sort((a, b) => {
-    if (a === "online") return -1;
-    if (b === "online") return 1;
-    return a?.localeCompare(b ?? "") ?? 0;
-});
-
-// Group projects by location
-const projectsByLocation = locations.map((location) => ({
-    location,
-    projects: projects.filter((project) => project.data.location === location),
+// Group projects, sorted alphabetically by title within each group
+const projectsByGroup = groups.map((group) => ({
+    group,
+    projects: projects
+        .filter((project) => groupOf(project) === group)
+        .sort((a, b) => a.data.title.localeCompare(b.data.title)),
 }));
 
 const projectCount = projects.length;
@@ -58,9 +57,9 @@ const categoryCount = new Set(projects.map((project) => project.data.category)).
         )
     }
     {
-        projectsByLocation.map(({ location, projects }) => (
+        projectsByGroup.map(({ group, projects }) => (
             <>
-                {location && projectsByLocation.length > 0 && <h3 class="text-capitalize mb-3 mt-4">{location}</h3>}
+                {group && <h3 class="text-capitalize mb-3 mt-4">{group.replaceAll("-", " ")}</h3>}
                 {projects.map((project) => (
                     <Project id={project.id} {...project.data} />
                 ))}

--- a/sites/main-site/src/content/events/2026/hackathon-barcelona.mdx
+++ b/sites/main-site/src/content/events/2026/hackathon-barcelona.mdx
@@ -118,7 +118,7 @@ try to achieve by the end of the hackathon.
 
 ## List of projects
 
-<HackathonModalProjectList eventPath="hackathon-barcelona-2026" />
+<HackathonModalProjectList eventPath="hackathon-barcelona-2026" groupBy="category" />
 
 # Code of conduct
 


### PR DESCRIPTION
Hackathon project lists are grouped by location. That works well for March-style distributed events, but on a single-venue hackathon every project sits under one heading that tells you nothing — see the [Barcelona 2026 project list](https://nf-co.re/events/2026/hackathon-barcelona#list-of-projects), where all five projects are under "Barcelona".

This adds an optional `groupBy` prop to `ListProjects.astro`, so the person writing the event MDX can choose to group by project category instead:

```astro
<HackathonModalProjectList eventPath="hackathon-barcelona-2026" groupBy="category" />
```

Projects are now also sorted alphabetically by title within each group, whichever grouping is used.

`groupBy` defaults to `location` and every other event page omits it, so their output is unchanged. Only the Barcelona / October 2026 page opts in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@netlify /events/2026/hackathon-barcelona