### PR TITLE
Add vscode_markdown.css symlink to main-site public folder

### DIFF
--- a/sites/main-site/public/vscode_markdown.css
+++ b/sites/main-site/public/vscode_markdown.css
@@ -1,0 +1,1 @@
+../../../public/vscode_markdown.css


### PR DESCRIPTION
`public/vscode_markdown.css` was missed when the site was split into `sites/*/`, so https://nf-co.re/vscode_markdown.css currently 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)