### PR TITLE
Add nf-core/seqinspector improvements project for Barcelona hackathon 2026

### DIFF
--- a/sites/main-site/src/content/hackathon-projects/hackathon-barcelona-2026/seqinspector-improvements.md
+++ b/sites/main-site/src/content/hackathon-projects/hackathon-barcelona-2026/seqinspector-improvements.md
@@ -1,0 +1,24 @@
+---
+title: nf-core/seqinspector improvements
+category: pipelines
+slack: https://nfcore.slack.com/channels/seqinspector
+location: Barcelona
+image: "/assets/images/events/2026/hackathon-march/nfcore-seqinspector-logo-hex-light.png"
+image_alt: "nf-core/seqinspector logo"
+leaders:
+  FranBonath:
+    name: Franziska Bonath
+    slack: https://nfcore.slack.com/team/UGP9YUCKD
+---
+
+## Goal
+
+Improve the nf-core/seqinspector pipeline with bug fixes, performance enhancements, and documentation updates.
+
+## Tasks
+
+_Tasks will be added closer to the event. Check back for updates._
+
+:::note
+Keep an eye on this page for more updates.
+:::


### PR DESCRIPTION
New hackathon project page for nf-core/seqinspector at the Barcelona hackathon (October 2026).

## Changes
- Project file: `sites/main-site/src/content/hackathon-projects/hackathon-barcelona-2026/seqinspector-improvements.md`
- Reuses existing image: `sites/main-site/src/assets/images/events/2026/hackathon-march/nfcore-seqinspector-logo-hex-light.png`

## Project Details
- **Title**: nf-core/seqinspector improvements
- **Category**: pipelines
- **Slack**: #seqinspector
- **Leader**: Franziska Bonath (@FranBonath)
- **Goal**: Fix bugs, improve performance, and update documentation

---
*Generated via [opencode](https://opencode.ai)*
Verified by @maxulysse

@netlify /hackathon-projects/hackathon-barcelona-2026/seqinspector-improvements