### PR TITLE
Add monitoring responsibility for review requests

### DIFF
--- a/sites/docs/src/content/docs/community/governance/core-team.mdx
+++ b/sites/docs/src/content/docs/community/governance/core-team.mdx
@@ -255,6 +255,7 @@ Duties for core team weekly 'on-call' rotation:
 - Distribute first release reviews => [Slack](https://nfcore.slack.com/archives/C08K66XCZSL)
 - Facilitate discussions and handling acceptance/rejection procedures on nf-core/proposals (pipelines, RFCs, SIGs, etc.) => [Github](http://github.com/nf-core/proposals) and [Slack](https://nfcore.slack.com/archives/CE6SDEDAA)
 - Add new community members to the GitHub organisation => [Github](http://github.com/orgs/nf-core/people) and [Slack](https://nfcore.slack.com/archives/CEB982K2T)
+- Monitor review requests for nf-core/configs and redirect to responsible maintainer or core member.
 - Monitor [#request-core](https://nfcore.slack.com/archives/C09H6NYHR9T) channel for requests to:
     - Upload test data to AWS S3 nf-core-awsmegatest buckets for new pipelines
     - Upload containers to [quay.io](https://quay.io/)


### PR DESCRIPTION
Added a responsibility to monitor review requests for nf-core/configs and redirect them to the appropriate maintainer or core member.

@netlify /docs/community/governance/core-team