### PR TITLE
Fix relative links between pipeline docs pages

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -24,6 +24,26 @@ jobs:
 
       - name: Run prek
         uses: j178/prek-action@4e14d07f9231acabce116ccfca13b13dd9755ece # v3.0.0
+  unit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: setup node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm run test-unit
   vale:
     runs-on: ubuntu-latest
     steps:

--- a/bin/satteri/mdast-github-markdown.test.ts
+++ b/bin/satteri/mdast-github-markdown.test.ts
@@ -26,6 +26,15 @@ test("markdown links point at the same pipeline and version", () => {
 
 test("files without a page on the website still go to GitHub", () => {
     assert.equal(rewriteLink("../CHANGELOG.md", "docs"), "https://github.com/nf-core/mag/blob/2.5.4/CHANGELOG.md");
+    // anchors survive: the reader lands on the release section, not the top of the changelog
+    assert.equal(
+        rewriteLink("../CHANGELOG.md#v250", "docs"),
+        "https://github.com/nf-core/mag/blob/2.5.4/CHANGELOG.md#v250",
+    );
+    assert.equal(
+        rewriteLink("CITATIONS.md#bowtie2", ""),
+        "https://github.com/nf-core/mag/blob/2.5.4/CITATIONS.md#bowtie2",
+    );
     assert.equal(rewriteLink("CITATIONS.md", ""), "https://github.com/nf-core/mag/blob/2.5.4/CITATIONS.md");
     assert.equal(rewriteLink("../assets/foo.csv", "docs"), "https://github.com/nf-core/mag/blob/2.5.4/assets/foo.csv");
 });

--- a/bin/satteri/mdast-github-markdown.test.ts
+++ b/bin/satteri/mdast-github-markdown.test.ts
@@ -1,0 +1,36 @@
+// Link rewriting checks for createGitHubMarkdownPlugin: run with `npm run test-unit`.
+// Pipeline docs pages are served at trailing-slash URLs, so a relative href to a
+// sibling doc resolves one level too deep and 404s — see nf-core/website#4384.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createGitHubMarkdownPlugin } from "./mdast-github-markdown.ts";
+
+const ctx = { setProperty: (node: any, key: string, value: any) => (node[key] = value) };
+
+function rewriteLink(url: string, parentDirectory: string): string {
+    const plugin: any = createGitHubMarkdownPlugin({ repo: "mag", ref: "2.5.4", version: "dev", parentDirectory });
+    const node: any = { url };
+    plugin.link(node, ctx);
+    return node.url;
+}
+
+test("markdown links point at the same pipeline and version", () => {
+    assert.equal(rewriteLink("usage.md#a-note", "docs"), "/mag/dev/docs/usage/#a-note");
+    assert.equal(rewriteLink("usage.md", "docs"), "/mag/dev/docs/usage/");
+    assert.equal(rewriteLink("../usage.md", "docs/subdir"), "/mag/dev/docs/usage/");
+    assert.equal(rewriteLink("subdir/page.mdx", "docs"), "/mag/dev/docs/subdir/page/");
+    // README (parentDirectory "") linking into the docs pages
+    assert.equal(rewriteLink("docs/usage.md", ""), "/mag/dev/docs/usage/");
+    assert.equal(rewriteLink("../README.md", "docs"), "/mag/dev/");
+});
+
+test("files without a page on the website still go to GitHub", () => {
+    assert.equal(rewriteLink("../CHANGELOG.md", "docs"), "https://github.com/nf-core/mag/blob/2.5.4/CHANGELOG.md");
+    assert.equal(rewriteLink("CITATIONS.md", ""), "https://github.com/nf-core/mag/blob/2.5.4/CITATIONS.md");
+    assert.equal(rewriteLink("../assets/foo.csv", "docs"), "https://github.com/nf-core/mag/blob/2.5.4/assets/foo.csv");
+});
+
+test("absolute and anchor-only links are left alone", () => {
+    assert.equal(rewriteLink("https://nf-co.re/usage.md", "docs"), "https://nf-co.re/usage.md");
+    assert.equal(rewriteLink("#anchor-only", "docs"), "#anchor-only");
+});

--- a/bin/satteri/mdast-github-markdown.ts
+++ b/bin/satteri/mdast-github-markdown.ts
@@ -15,7 +15,7 @@
 import { defineMdastPlugin } from "satteri";
 
 const SPECIAL_FILES_REGEX = /^(\.github\/CONTRIBUTING\.md|CITATIONS\.md|CHANGELOG\.md|\.config)$/;
-const MDX_ANCHOR_REGEX = /\.mdx?#/;
+const MD_LINK_REGEX = /\.mdx?($|#|\?)/;
 const ADMONITION_REGEX = /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*(.*)/;
 const IMG_SRC_REGEX = /<img(.*?)src="(.*?)"/g;
 const SOURCE_SRCSET_REGEX = /<source(.*?)srcset="(.*?)"/g;
@@ -74,13 +74,36 @@ export interface GitHubMarkdownOptions {
     org?: string;
     repo: string;
     ref: string;
+    /** URL segment of the page being rendered ("latest", "dev", "4.0.0"), not necessarily `ref`. */
+    version: string;
     parentDirectory?: string;
 }
 
 export function createGitHubMarkdownPlugin(options: GitHubMarkdownOptions) {
-    const { org = "nf-core", repo, ref, parentDirectory = "" } = options;
+    const { org = "nf-core", repo, ref, version, parentDirectory = "" } = options;
     const baseRawUrl = `https://raw.githubusercontent.com/${org}/${repo}/${ref}/`;
     const baseRepoUrl = `https://github.com/${org}/${repo}/blob/${ref}/`;
+
+    /**
+     * Map a relative link to another markdown file onto the website, root-relative:
+     * "usage.md#anchor" in docs/output.md → "/<pipeline>/<version>/docs/usage/#anchor".
+     *
+     * Docs pages are served at trailing-slash URLs, so a relative href resolves one
+     * level too deep (".../docs/output/usage" → 404); the link has to be absolute.
+     * `version` (not `ref`) keeps the reader on the channel they are browsing, so a
+     * link followed from /latest/ or /dev/ stays there.
+     *
+     * Markdown files outside docs/ have no page on the website, so they go to GitHub.
+     */
+    function markdownLinkUrl(url: string): string {
+        // Resolve "../" etc. against the directory of the file being rendered.
+        const resolved = new URL(url, `https://n/${parentDirectory ? parentDirectory + "/" : ""}`);
+        const path = resolved.pathname.slice(1);
+        const page = path.replace(/\.mdx?$/, "");
+        if (page === "README") return `/${repo}/${version}/${resolved.hash}`;
+        if (!page.startsWith("docs/")) return `${baseRepoUrl}${path}${resolved.search}`;
+        return `/${repo}/${version}/${page}/${resolved.search}${resolved.hash}`;
+    }
 
     return defineMdastPlugin({
         name: "github-markdown",
@@ -95,8 +118,8 @@ export function createGitHubMarkdownPlugin(options: GitHubMarkdownOptions) {
                 ctx.setProperty(node, "url", `${baseRepoUrl}${node.url}`);
             } else if (node.url.includes("../assets/")) {
                 ctx.setProperty(node, "url", `${baseRepoUrl}${node.url.replace("../assets/", "assets/")}`);
-            } else if (MDX_ANCHOR_REGEX.test(node.url)) {
-                ctx.setProperty(node, "url", node.url.replace(MDX_ANCHOR_REGEX, "#"));
+            } else if (MD_LINK_REGEX.test(node.url)) {
+                ctx.setProperty(node, "url", markdownLinkUrl(node.url));
             }
         },
         code(node: any, ctx) {

--- a/bin/satteri/mdast-github-markdown.ts
+++ b/bin/satteri/mdast-github-markdown.ts
@@ -100,8 +100,8 @@ export function createGitHubMarkdownPlugin(options: GitHubMarkdownOptions) {
         const resolved = new URL(url, `https://n/${parentDirectory ? parentDirectory + "/" : ""}`);
         const path = resolved.pathname.slice(1);
         const page = path.replace(/\.mdx?$/, "");
-        if (page === "README") return `/${repo}/${version}/${resolved.hash}`;
-        if (!page.startsWith("docs/")) return `${baseRepoUrl}${path}${resolved.search}`;
+        if (page === "README") return `/${repo}/${version}/${resolved.search}${resolved.hash}`;
+        if (!page.startsWith("docs/")) return `${baseRepoUrl}${path}${resolved.search}${resolved.hash}`;
         return `/${repo}/${version}/${page}/${resolved.search}${resolved.hash}`;
     }
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "build-component-json": "node bin/components.json.js",
         "check-api-catalog": "node bin/check-api-catalog.js",
         "update": "npx npm-check-updates --interactive --format group --workspaces",
-        "test-all": "for dir in sites/*; do (cd $dir && npm run test); done"
+        "test-all": "for dir in sites/*; do (cd $dir && npm run test); done",
+        "test-unit": "node --test bin/satteri/*.test.ts"
     },
     "workspaces": [
         "sites/*"

--- a/sites/main-site/utils/pipelineMarkdown.ts
+++ b/sites/main-site/utils/pipelineMarkdown.ts
@@ -8,6 +8,7 @@ export async function renderPipelineMarkdown(
     repo: string,
     ref: string,
     parentDir: string,
+    version: string,
 ): Promise<{ html: string; headings: MarkdownHeading[] }> {
     const { features, mdastPlugins, hastPlugins } = createSatteriPluginSets();
     // The processor is created per call: the GitHub URL rewriting is parameterised by
@@ -17,7 +18,7 @@ export async function renderPipelineMarkdown(
     const processor = await createSatteriMarkdownProcessor({
         syntaxHighlight: false,
         features,
-        mdastPlugins: [createGitHubMarkdownPlugin({ repo, ref, parentDirectory: parentDir }), ...mdastPlugins],
+        mdastPlugins: [createGitHubMarkdownPlugin({ repo, ref, version, parentDirectory: parentDir }), ...mdastPlugins],
         hastPlugins,
     });
     const { code: html, metadata } = await processor.render(trimGitHubReadme(body));

--- a/sites/pipelines/src/pages/[pipeline]/[version]/docs/[...md_file].astro
+++ b/sites/pipelines/src/pages/[pipeline]/[version]/docs/[...md_file].astro
@@ -82,9 +82,6 @@ let leftSidebar = md_files.filter((file) => file.id.split("/")[0] === section).l
 
 let sections: SidebarEntry[] = [];
 
-// add trailing slash to url if missing
-let url = Astro.url.pathname.endsWith("/") ? Astro.url.pathname : Astro.url.pathname + "/";
-url = url.replace(/\.html\/$/, "/");
 // drop everything after docs/
 if (leftSidebar) {
     // Convert md_files to match the expected CollectionEntry<'docs'> structure
@@ -137,6 +134,7 @@ const { html: Content, headings: rawHeadings } = await renderPipelineMarkdown(
     pipeline,
     version_tag_name,
     parentDir,
+    version,
 );
 let headings = rawHeadings.filter((h) => h.depth <= 3);
 ---

--- a/sites/pipelines/src/pages/[pipeline]/[version]/index.astro
+++ b/sites/pipelines/src/pages/[pipeline]/[version]/index.astro
@@ -38,7 +38,13 @@ const is_archived = meta.archived;
 const version_tag_name = version === "latest" ? versions[0] : version;
 let entry = await getEntry("pipelines", pipeline + "/" + version_tag_name + "/README");
 
-const { html: Content, headings } = await renderPipelineMarkdown(entry?.body ?? "", pipeline, version_tag_name, "");
+const { html: Content, headings } = await renderPipelineMarkdown(
+    entry?.body ?? "",
+    pipeline,
+    version_tag_name,
+    "",
+    version,
+);
 if (version_tag_name !== "dev") {
     meta.doi = entry?.data?.doi;
 }


### PR DESCRIPTION
Closes #4384.

Relative links between a pipeline's own docs pages (`[text](usage.md#anchor)`, which renders correctly on GitHub) 404 on the website. Docs pages are served at trailing-slash URLs, so a still-relative href resolves one level too deep: on `/mag/dev/docs/output/`, `usage#a-note-on-long-read-filtering` goes to `/mag/dev/docs/output/usage` instead of `/mag/dev/docs/usage/`. It's invisible in PR review because GitHub renders the same source link fine.

## History

We used to handle this, and the handling was dropped by accident.

`6f3caa3a4` (June 2023, "fix relative links in pipeline docs") added a regex pass over the raw markdown in the docs page component, before render:

```js
// make relative links to other markdown files absolute to current Astro.url.pathname
content = content.replaceAll(/\[([^\]]+)\]\((?!http)(?!#)(.*?)\)/g, (match, p1, p2) => {
    const link = [...new Set([...url.split('/').filter(i => i), ...p2.split('/').filter(i => i)])].join('/');
    return `[${p1}](/${link})`;
});
```

`96d2e1903` ("move cached markdown files into content collections on build") then replaced the fetch-and-string-munge step with `entry.render()`, and this pass was not carried over into the remark plugins that took over. Everything since — `remark-github-markdown.js`, the `rehype-urls` `urlTransformer`, and today's satteri plugins — only strips the `.md` extension. That leaves the href relative, which is the bug. So this is a restoration rather than a new feature.

## What this does

The rewrite goes back in as part of `createGitHubMarkdownPlugin` in `bin/satteri/mdast-github-markdown.ts`, where the anchored-link branch already lived, so anchored and plain links take the same path instead of one branch here and one in `hast-markdown-links.ts`:

```ts
function markdownLinkUrl(url: string): string {
    // Resolve "../" etc. against the directory of the file being rendered.
    const resolved = new URL(url, `https://n/${parentDirectory ? parentDirectory + "/" : ""}`);
    const path = resolved.pathname.slice(1);
    const page = path.replace(/\.mdx?$/, "");
    if (page === "README") return `/${repo}/${version}/${resolved.hash}`;
    if (!page.startsWith("docs/")) return `${baseRepoUrl}${path}${resolved.search}`;
    return `/${repo}/${version}/${page}/${resolved.search}${resolved.hash}`;
}
```

Three things worth calling out:

**Version, not ref.** `version` is a new option, threaded through `renderPipelineMarkdown()` from `Astro.params.version`, and it is deliberately not `ref`. `renderPipelineMarkdown` is passed `version_tag_name`, so a URL built from `ref` would move a reader on `/mag/latest/docs/` onto a pinned version. Preserving the channel is the reason to fix this properly rather than tell pipelines to hardcode `https://nf-co.re/<pipeline>/usage#anchor` — that workaround always lands on the released docs, so a reader browsing `/dev/` is silently taken out of the version they were reading, and an anchor for an unreleased section doesn't resolve at all until the next release.

**`new URL` for resolution**, so a `../` in a link from a docs subdirectory keeps working. The 2023 version joined deduplicated path segments, which mangled repeated segments and did not understand `../`.

**Markdown with no page on the site goes to GitHub.** Previously only an exact `CHANGELOG.md` / `CITATIONS.md` / `.github/CONTRIBUTING.md` matched, so `../CHANGELOG.md` from a docs page fell through to a relative 404. Now the path is resolved first, so the prefixed forms are caught too.

Also deleted the dead `url` variable at the top of the docs route — the last leftover of the 2023 version, unused since the pass it fed was removed.

## Testing

`npm run test-unit` (new root script, plain `node --test`) runs `bin/satteri/mdast-github-markdown.test.ts`: sibling links, anchored links, `../` from a docs subdirectory, README links from the pipeline index, non-docs markdown, and absolute/anchor-only links left alone. There was no unit test setup in the repo before; the existing Playwright suites need a deployed preview, and CI only runs them for `sites/main-site` changes, so a link-rewriting regression like this one had nothing to catch it.

Rendering `see the [note](usage.md#a-note-on-long-read-filtering)` through the real satteri processor (same plugin sets as `renderPipelineMarkdown`, `parentDirectory: "docs"`) gives:

```html
<p>see the <a href="/mag/dev/docs/usage/#a-note-on-long-read-filtering">note</a> ...
```

**This is not visible on the deploy preview.** `sites/main-site/astro.config.mjs` proxies `/:pipeline/:version/*` to `https://nf-core-pipelines.netlify.app` — the hardcoded production host, not a preview one — and the pipelines sub-site does not publish a deploy preview of its own. So `deploy-preview-4385--nf-core-main-site.netlify.app/mag/dev/docs/output/` serves the live pipelines site and is byte-identical to nf-co.re, whatever this branch does. Any change to a pipeline page is unpreviewable on a PR today, which seems worth fixing separately.


@netlify /[pipeline]/[version]