### PR TITLE
Fix broken links for 'Edit' button in page header

### DIFF
--- a/sites/docs/src/pages/docs/[...doc].astro
+++ b/sites/docs/src/pages/docs/[...doc].astro
@@ -156,11 +156,7 @@ if (currentGroup.length > 0) {
 }
 
 const docType = Astro.props.doc.data.type;
-const isMDX = Astro.props.doc.filePath?.endsWith(".mdx");
-const md_github_url =
-    "https://github.com/nf-core/website/blob/main/sites/docs/src/content/docs/" +
-    Astro.props.doc.id +
-    (isMDX ? ".mdx" : ".md");
+const md_github_url = "https://github.com/nf-core/website/blob/main/sites/docs/" + Astro.props.doc.filePath;
 // remove leading and trailing slash
 const splitUrl = `${Astro.url.pathname}/`.replace(/^\/|\/$/g, "").split("/");
 // check if markdown file starts with a heading (markdown or html)

--- a/sites/docs/src/pages/docs/nf-core-tools/api_reference/[version]/[...slug].astro
+++ b/sites/docs/src/pages/docs/nf-core-tools/api_reference/[version]/[...slug].astro
@@ -85,21 +85,24 @@ headings.map((heading) => {
     heading.text = heading.text.replaceAll(/\./g, ".\u200B");
 });
 
-// try to figure out github URL to the source file from file path
-let md_github_url = "";
-const base_url = `https://github.com/nf-core/tools/blob/${version_tag_name}/nf_core/`;
-const file_name =
-    entry.filePath?.replace("src/content/api_reference/", "").split("/").pop()?.replace(".md", ".py") || "";
-// check if entry.id contains "pipeline_lint_tests"
-if (entry.id.includes("pipeline_lint_tests")) {
-    md_github_url = base_url + "lint/" + file_name;
-} else if (entry.id.includes("module_lint_tests") || entry.id.includes("subworkflow_lint_tests")) {
-    // append to base url either to modules/lint or subworkflows/lint
-    const component_type = entry.id.includes("module_lint_tests") ? "modules" : "subworkflows";
-    md_github_url = base_url + component_type + "/lint/" + file_name;
-} else if (entry.id.includes("api")) {
-    md_github_url = base_url + file_name;
-}
+// Path of this page within its version directory, e.g. api/pipelines/create
+const [section, ...doc_path] =
+    entry.filePath?.replace("src/content/api_reference/", "").replace(/\.md$/, "").split("/").slice(1) || [];
+// nf-core/tools moved the pipeline commands under nf_core/pipelines/ in v3.0
+const pipelines_prefix = version_tag_name === "dev" || Number(version_tag_name?.split(".")[0]) >= 3 ? "pipelines/" : "";
+const source_dirs: Record<string, string> = {
+    api: "nf_core",
+    pipeline_lint_tests: `nf_core/${pipelines_prefix}lint`,
+    module_lint_tests: "nf_core/modules/lint",
+    subworkflow_lint_tests: "nf_core/subworkflows/lint",
+};
+// Pages under api/ mirror the module path, lint tests are named after the file in their lint
+// directory. Pages for a package rather than a module have no .py of their own and will 404.
+const source_file = doc_path.join("/").replace(/-/g, "_") + ".py"; // params-file.md documents params_file.py
+const md_github_url =
+    section in source_dirs && doc_path.length && doc_path.at(-1) !== "index"
+        ? `https://github.com/nf-core/tools/blob/${version_tag_name}/${source_dirs[section]}/${source_file}`
+        : "";
 
 let tools: CollectionEntry<"api_reference">[] = await getCollection("api_reference");
 // replace tools.id with tools.filePath
@@ -110,6 +113,16 @@ tools = tools.map((tool) => {
 // filter tools by version_
 const versioned_tools = tools.filter((tool) => tool.id.split("/")[0] === version_tag_name);
 const section_names = [...new Set(versioned_tools.map((entry) => entry.id.split("/")[1]))];
+const base_url = "/docs/nf-core-tools/api_reference/";
+// Tool ids start with the resolved version tag, but links keep the version being browsed,
+// so that navigating from /latest/ doesn't pin you to the release it points at.
+const href_for = (id: string) => base_url + [version, ...id.split("/").slice(1)].join("/");
+const current_path = Astro.url.pathname.replace(".html", "").replace(/\/$/, "");
+// Most pages exist for some versions only, so offer the version front page when this one is missing
+const tool_ids = new Set(tools.map((tool) => tool.id));
+const slug_id = Astro.params.slug?.replace(/\/$/, "/index");
+const version_url = (v: string) =>
+    base_url + (slug_id && tool_ids.has(`${v}/${slug_id}`) ? `${v}/${Astro.params.slug}` : v);
 const sections: SidebarEntry[] = section_names
     .filter((entry) => entry !== "index")
     .map((entry) => {
@@ -117,12 +130,11 @@ const sections: SidebarEntry[] = section_names
             type: "group",
             id: entry,
             label: entry === "api" ? "API" : entry.replace(/_/g, " ").replace(/^\w/, (c) => c.toUpperCase()),
-            href:
-                "/docs/nf-core-tools/api_reference/" +
-                versioned_tools
-                    .find((tool_entry) => tool_entry.id.endsWith("index") && tool_entry.id.split("/")[1] === entry)
-                    ?.id.replace(/index\.md$/, "index")
-                    .replace("docs/", ""),
+            href: href_for(
+                versioned_tools.find(
+                    (tool_entry) => tool_entry.id.endsWith("index") && tool_entry.id.split("/")[1] === entry,
+                )?.id || "",
+            ),
             collapsed: true,
             isCurrent: false,
             entries: versioned_tools
@@ -134,16 +146,8 @@ const sections: SidebarEntry[] = section_names
                             type: "link",
                             label: `<code>${tool_entry.id?.split("/")[2].replace(/\.md$/, "")}</code>`,
                             id: tool_entry.id.split("/")[2].replace(/\.md$/, ""),
-                            href:
-                                "/docs/nf-core-tools/api_reference/" +
-                                tool_entry.id.replace("docs/", "").replace(/\.md$/, ""),
-                            isCurrent: Astro.url.pathname
-                                .replace(".html", "")
-                                .replace("/latest/", `/${version_tag_name}/`)
-                                .includes(
-                                    "/docs/nf-core-tools/api_reference/" +
-                                        tool_entry.id.replace("docs/", "").replace(/\.md$/, ""),
-                                ),
+                            href: href_for(tool_entry.id),
+                            isCurrent: current_path === href_for(tool_entry.id),
                         };
                     } else {
                         return {
@@ -167,16 +171,8 @@ const sections: SidebarEntry[] = section_names
                                               type: "link",
                                               label: `<code>${grand_child.id?.split("/")[3].replace(/\.md$/, "")}</code>`,
                                               id: grand_child.id.split("/")[3].replace(/\.md$/, ""),
-                                              href:
-                                                  "/docs/nf-core-tools/api_reference/" +
-                                                  grand_child.id.replace("docs/", "").replace(/\.md$/, ""),
-                                              isCurrent: Astro.url.pathname
-                                                  .replace(".html", "")
-                                                  .replace("/latest/", `/${version_tag_name}/`)
-                                                  .includes(
-                                                      "/docs/nf-core-tools/api_reference/" +
-                                                          grand_child.id.replace("docs/", "").replace(/\.md$/, ""),
-                                                  ),
+                                              href: href_for(grand_child.id),
+                                              isCurrent: current_path === href_for(grand_child.id),
                                           };
                                       })
                                 : [
@@ -184,16 +180,8 @@ const sections: SidebarEntry[] = section_names
                                           type: "link",
                                           label: `<code>${tool_entry.id?.split("/")[2].replace(/\.md$/, "")}</code>`,
                                           id: tool_entry.id.split("/")[2].replace(/\.md$/, ""),
-                                          href:
-                                              "/docs/nf-core-tools/api_reference/" +
-                                              tool_entry.id.replace("docs/", "").replace(/\.md$/, ""),
-                                          isCurrent: Astro.url.pathname
-                                              .replace(".html", "")
-                                              .replace("/latest/", `/${version_tag_name}/`)
-                                              .includes(
-                                                  "/docs/nf-core-tools/api_reference/" +
-                                                      tool_entry.id.replace("docs/", "").replace(/\.md$/, ""),
-                                              ),
+                                          href: href_for(tool_entry.id),
+                                          isCurrent: current_path === href_for(tool_entry.id),
                                       },
                                   ],
                         };
@@ -258,10 +246,7 @@ sections.sort((a, b) => {
                 {
                     versions &&
                         versions.map((v) => {
-                            let url = Astro.url.pathname.replace(
-                                `tools/api_reference/${version}`,
-                                `tools/api_reference/${v}`,
-                            );
+                            const url = version_url(v);
                             return (
                                 <li>
                                     <a class={"dropdown-item " + (v === version_tag_name ? "active" : "")} href={url}>

--- a/sites/main-site/src/pages/[about].astro
+++ b/sites/main-site/src/pages/[about].astro
@@ -18,7 +18,7 @@ const subtitle = Astro.props.about.data.description;
 let md_github_url = Astro.props.about.data.md_github_url;
 const { headings, Content } = await render(Astro.props.about);
 if (!md_github_url) {
-    md_github_url = "https://github.com/nf-core/website/blob/main/src/content/about/" + Astro.props.about.id;
+    md_github_url = "https://github.com/nf-core/website/blob/main/sites/main-site/" + Astro.props.about.filePath;
 }
 const minHeadingDepth = Astro.props.about.data.minHeadingDepth || 1;
 const maxHeadingDepth = Astro.props.about.data.maxHeadingDepth || 4;

--- a/sites/main-site/src/pages/advisories/[...advisory].astro
+++ b/sites/main-site/src/pages/advisories/[...advisory].astro
@@ -27,8 +27,7 @@ let { headings, Content } = await render(advisory);
 if (frontmatter.references) {
     headings = [...headings, { depth: 1, slug: "references", text: "References" }];
 }
-const md_github_url =
-    "https://github.com/nf-core/website/blob/main/sites/main-site/src/content/advisories/" + advisory.id + ".md";
+const md_github_url = "https://github.com/nf-core/website/blob/main/sites/main-site/" + advisory.filePath;
 
 const addEntriesToSection = (sections, advisories: CollectionEntry<"advisories">[]) => {
     // First, group advisories by year

--- a/sites/main-site/src/pages/blog/[...blogpost].astro
+++ b/sites/main-site/src/pages/blog/[...blogpost].astro
@@ -53,7 +53,7 @@ const sections: SidebarEntry[] = years.map((year) => {
 const { headings, Content } = await render(post);
 const title = post.data.title;
 const subtitle = post.data.subtitle;
-const md_github_url = "https://github.com/nf-core/website/blob/main/sites/main-site/src/content/blog/" + post.id;
+const md_github_url = "https://github.com/nf-core/website/blob/main/sites/main-site/" + post.filePath;
 ---
 
 <MarkdownTocLayout

--- a/sites/main-site/src/pages/events/[...event].astro
+++ b/sites/main-site/src/pages/events/[...event].astro
@@ -26,8 +26,7 @@ const subtitle = event.data.subtitle;
 let frontmatter = event.data;
 const { headings, Content } = await render(event);
 
-const md_github_url =
-    "https://github.com/nf-core/website/blob/main/sites/main-site/src/content/events/" + event.id + ".md";
+const md_github_url = "https://github.com/nf-core/website/blob/main/sites/main-site/" + event.filePath;
 
 let video = event.data.youtubeEmbed;
 // convert video to array if it is string

--- a/sites/main-site/src/pages/hackathon-projects/[...slug].astro
+++ b/sites/main-site/src/pages/hackathon-projects/[...slug].astro
@@ -32,10 +32,7 @@ if (!color && category) {
     if (category == "special-interest-groups") this_color = "#238636";
 }
 
-const md_github_url =
-    "https://github.com/nf-core/website/blob/main/sites/main-site/src/content/hackathon-projects/" +
-    project.id +
-    ".mdx";
+const md_github_url = "https://github.com/nf-core/website/blob/main/sites/main-site/" + project.filePath;
 
 const images = import.meta.glob("../../assets/**");
 const showSidebar = intro_video || image || leaders || slack || category || location;

--- a/sites/main-site/src/pages/special-interest-groups/[...slug].astro
+++ b/sites/main-site/src/pages/special-interest-groups/[...slug].astro
@@ -16,8 +16,7 @@ export async function getStaticPaths() {
 }
 const { entry, section } = Astro.props;
 const { headings, Content } = await render(entry);
-const md_github_url =
-    "https://github.com/nf-core/website/blob/main/sites/main-site/src/content/special-interest-groups/" + entry.id;
+const md_github_url = "https://github.com/nf-core/website/blob/main/sites/main-site/" + entry.filePath;
 const current_section = groupEntries.filter((group) => group.id.replace(/\.[^/.]+$/, "").split("/")[0] === section);
 const indexPage =
     "/special-interest-groups/" +

--- a/sites/pipelines/src/pages/[pipeline]/[version]/docs/[...md_file].astro
+++ b/sites/pipelines/src/pages/[pipeline]/[version]/docs/[...md_file].astro
@@ -19,6 +19,7 @@ export async function getStaticPaths() {
             md_files: { id: string; data: {} }[];
             description: string | null;
             actual_md_file?: string;
+            doc_file: string;
         };
     }[] = [];
 
@@ -50,7 +51,7 @@ export async function getStaticPaths() {
                         version: release.tag_name,
                         md_file: slug,
                     },
-                    props: sharedProps,
+                    props: { ...sharedProps, doc_file: file },
                 });
 
                 // For index files, also serve the directory-style URL (e.g. usage/DEanalysis/ → usage/DEanalysis/index)
@@ -62,7 +63,7 @@ export async function getStaticPaths() {
                             version: release.tag_name,
                             md_file: dirSlug,
                         },
-                        props: { ...sharedProps, actual_md_file: slug },
+                        props: { ...sharedProps, actual_md_file: slug, doc_file: file },
                     });
                 }
             }
@@ -72,7 +73,7 @@ export async function getStaticPaths() {
     return paths;
 }
 let { pipeline, version, md_file } = Astro.params;
-const { versions, md_files, description, actual_md_file } = Astro.props;
+const { versions, md_files, description, actual_md_file, doc_file } = Astro.props;
 // Use actual_md_file when serving a directory-style URL (e.g. usage/DEanalysis/ → usage/DEanalysis/index)
 const content_md_file = actual_md_file ?? md_file;
 
@@ -149,7 +150,7 @@ let headings = rawHeadings.filter((h) => h.depth <= 3);
     version={version}
     versions={versions}
     tabItems={md_files.map((file) => file.id)}
-    md_github_url={`https://github.com/nf-core/${pipeline}/blob/${version}/docs/${content_md_file}.md`}
+    md_github_url={`https://github.com/nf-core/${pipeline}/blob/${version_tag_name}/${doc_file}`}
     sections={sections}
     docSearchTags={[
         { name: "page_rank", content: "5" },

--- a/sites/pipelines/src/pages/[pipeline]/[version]/index.astro
+++ b/sites/pipelines/src/pages/[pipeline]/[version]/index.astro
@@ -49,7 +49,7 @@ if (version_tag_name !== "dev") {
     meta.doi = entry?.data?.doi;
 }
 
-const md_github_url = "https://github.com/nf-core/" + pipeline + "/blob/" + version + "/README.md";
+const md_github_url = "https://github.com/nf-core/" + pipeline + "/blob/" + version_tag_name + "/README.md";
 ---
 
 <PipelinePageLayout


### PR DESCRIPTION
The "Edit" button in page headers goes to a 404 on GitHub from many pages. Enough that I no longer bother trying it for any pages. This is sad as really like this feature.

I set Claude off on a hunt to try to track down anywhere it was broken and fix it.