### PR TITLE
Fix search: use `indices` array for DocSearch v5

### DIFF
--- a/sites/main-site/src/components/navbar/Search.astro
+++ b/sites/main-site/src/components/navbar/Search.astro
@@ -29,7 +29,7 @@ const { id = "docsearch" } = Astro.props;
 <script>
     const docsearchOpts = {
         appId: "01BY3A8NRJ",
-        indexName: "nf-co",
+        indices: ["nf-co"],
         apiKey: "c726615ab69f88b4e26bc891c97c1808",
         placeholder: "Search",
     };


### PR DESCRIPTION
The dependency bump in #4387 took `@docsearch/js` to v5, which replaced the single `indexName` option with an `indices` array. Search has been broken since then — the modal never mounts and the console shows:

```
Uncaught Error: Must supply at least one `indices` entry for DocSearch
```

One-line fix: `indexName: "nf-co"` → `indices: ["nf-co"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)