### PR TITLE
Fix Svelte hydration mismatch from nested `<p>` tags

### DIFF
--- a/sites/main-site/src/components/advisory/AdvisoryCard.svelte
+++ b/sites/main-site/src/components/advisory/AdvisoryCard.svelte
@@ -38,7 +38,7 @@
 
         {#snippet cardBody()}
             {#if showDescription}
-                <p class="mb-4">{@html frontmatter.subtitle}</p>
+                <div class="mb-4">{@html frontmatter.subtitle}</div>
             {/if}
             {#if metadataItems.length > 0}
                 <div class="mt-2 small">

--- a/sites/main-site/src/components/event/EventBannerElement.svelte
+++ b/sites/main-site/src/components/event/EventBannerElement.svelte
@@ -218,14 +218,14 @@
                                 >{event.data.title}</a
                             >
                         </h4>
-                        <p class="d-sm-none mb-1">
+                        <div class="d-sm-none mb-1">
                             <a href={"events/" + event.id + "/"} class="text-body text-decoration-none"
                                 >{@html event.data.subtitle}</a
                             ><span class={"badge bg-" + event_type_classes[event.data.type] + " small ms-3"}
                                 ><i class={event_type_icons[event.data.type] + " me-1"} aria-hidden="true"></i>
                                 {event.data.type}</span
                             >
-                        </p>
+                        </div>
                         <div class="small mb-1 mx-3 d-flex flex-column">
                             <a
                                 href={"events/" + event.id + "/"}

--- a/sites/main-site/src/components/event/EventCard.svelte
+++ b/sites/main-site/src/components/event/EventCard.svelte
@@ -41,7 +41,7 @@
     {/snippet}
     {#snippet cardBody()}
         {#if showDescription}
-            <p class="mb-0">{@html frontmatter.subtitle}</p>
+            <div class="mb-0">{@html frontmatter.subtitle}</div>
         {/if}
         <div
             class="d-flex align-items-center mt-2 flex-wrap justify-content-start"


### PR DESCRIPTION
Fixes this console error on the homepage:

```
client.DB-SaugC.js:1 https://svelte.dev/e/hydration_mismatch
```

Event and advisory subtitles are markdown-rendered, so `{@html subtitle}` inserts a `<p>` element. Wrapping that in another `<p>` is invalid HTML — the browser closes the outer paragraph early and scatters the following nodes, including Svelte's hydration anchors, into siblings. Hydration fails and the whole island is thrown away and re-rendered client-side.

Swaps the three wrapping `<p>` elements for `<div>`. Traced to `EventBannerElement` by hooking `astro-island` hydration; verified the warning is gone and the mobile layout is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)